### PR TITLE
plan(viz): background-subagent execution rule

### DIFF
--- a/docs/plans/2026-07-19-grok-compat-and-mermaid-viz.md
+++ b/docs/plans/2026-07-19-grok-compat-and-mermaid-viz.md
@@ -70,6 +70,15 @@ init.sh list, deterministic-output tests (shuffle test extended), renderer
 tests for each diagram, coverage sandbox convention respected.
 `/worklog:viz` plugin command = run roadmap-render --viz=all and show it.
 
+### Execution rule: always a background subagent
+
+Viz work never blocks the main thread. Both the implementation waves and the
+recurring runtime step (regenerate diagrams + republish the roadmap after log
+changes) are delegated to ONE background subagent, run in parallel with other
+tasks — the same non-blocking pattern plan-capture uses for ticket/wiki
+publishing. The main session folds the result in when the notification
+arrives; it never waits.
+
 ### Out of scope
 
 - `--html` interactive dashboard (Mermaid.js standalone) — separate plan if


### PR DESCRIPTION
Adds the execution rule to the viz plan: implementation and the recurring regenerate-and-republish step always run in one background subagent, parallel to other work — same non-blocking pattern as plan-capture's publishing. (Plans are append-friendly before scheduling; the design body is untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQGvi7bsvRuozgx4htCRY9