### PR TITLE
fix: ticket bodies readable by junior dev/PM (spec §13.4)

### DIFF
--- a/.claude/skills/plan-capture/SKILL.md
+++ b/.claude/skills/plan-capture/SKILL.md
@@ -10,10 +10,15 @@ description: Capture an approved plan as tracked work items. Use when exiting pl
        ## Tasks
 
        - [ ] (P1) Task title
+         One to three plain sentences under the checkbox become the task's
+         ticket body — written for a junior dev or a PM (spec §13.4):
+         what and why, no ULIDs.
          - [ ] Subtask of the task above
 
-   Priority token `(P0)`–`(P3)` optional, default P2. Prose (the *why*) goes
-   in other sections and is preserved verbatim in the plan doc.
+   Priority token `(P0)`–`(P3)` optional, default P2. **Every task gets a
+   description line** — a marker-only ticket body is a policy violation
+   (§13.4). Plan-level prose (the *why*) goes in other sections and is
+   preserved verbatim in the plan doc.
 
    Captured items are `kind:feature` by design — a plan's tasks deliver
    planned value. If a captured task is really a defect, retag it after
@@ -21,7 +26,8 @@ description: Capture an approved plan as tracked work items. Use when exiting pl
 
 2. Save it to a temp file and run:
 
-       bin/worklog plan-capture --slug <kebab-slug> --title "<plan title>" --file <tempfile>
+       bin/worklog plan-capture --slug <kebab-slug> --title "<plan title>" \
+           --body "<epic description a junior dev/PM can read>" --file <tempfile>
 
 3. Run `bin/worklog roadmap-render`, then commit `docs/plans/`,
    `docs/roadmap.md`, and `.work/todo.jsonl` together.

--- a/.claude/skills/work-track/SKILL.md
+++ b/.claude/skills/work-track/SKILL.md
@@ -15,9 +15,16 @@ only writer.
 
 ## Add an item
 
-    bin/worklog add "<title>" [--level epic|story|task|subtask] \
+    bin/worklog add "<title>" --body "<readable description>" \
+        [--level epic|story|task|subtask] \
         [--kind feature|bug|ops|triage] [--milestone v0.6.0] \
         [--priority P0-P3] [--parent <ulid>] [--labels a,b]
+
+**Every item gets a `--body` (spec §13.4).** One to three sentences a junior
+dev or a PM can read in the ticket: what the work is and why it matters. No
+ULIDs, no repo jargon in the reading path — the sync marker carries
+provenance, the body carries meaning. A ticket whose body is only a worklog
+id is a policy violation. Fix gaps with `worklog update <ulid> --body "..."`.
 
 Taxonomy rules (spec 5.4): epics are `feature` or `ops` only — kind is free
 at story/task/subtask; bugs may float free of any epic (`--parent` optional).

--- a/adapters/github/adapter
+++ b/adapters/github/adapter
@@ -206,7 +206,11 @@ def cmd_push():
     elif op == "update":
         if key is None:
             die(1, "push op=update with null key: dispatcher bug")
-        args = ["issue", "edit", str(key), "-R", repo]
+        args = ["issue", "edit", str(key), "-R", repo,
+                # body carries the marker + readable description (§13.4);
+                # without it, body edits authored locally never reach the
+                # ticket and update-synced issues stay marker-only.
+                "--body", build_body(marker, item)]
         if item.get("title"):
             args += ["--title", item["title"]]
         for lab in labels:

--- a/bin/plan_capture.py
+++ b/bin/plan_capture.py
@@ -7,11 +7,13 @@ Pure functions only. All log writing happens in `worklog` (invariant 15.4).
 Task syntax, inside a `## Tasks` section of the draft:
 
     - [ ] (P1) Extract auth middleware
-      - [ ] Write failing test        <- indented = subtask of the task above
+      Plain lines under a task are its description -- written for a junior
+      dev or a PM: what and why, no ULIDs (spec section 13.4).
+      - [ ] Write failing test        <- indented checkbox = subtask
 
 `[x]` boxes count too (a captured plan may arrive partially done). Checkboxes
 outside the Tasks section are prose and are ignored. Priority token optional,
-default P2.
+default P2. Description lines attach to the most recent task as `body`.
 """
 import re
 
@@ -30,10 +32,14 @@ def parse_tasks(draft):
             continue
         m = TASK_RE.match(line)
         if not m:
+            if stripped and tasks:
+                prev = tasks[-1]
+                prev["body"] = (prev["body"] + "\n" + stripped
+                                if prev["body"] else stripped)
             continue
         indent, prio, title = m.groups()
         tasks.append({"title": title, "priority": prio or "P2",
-                      "subtask": bool(indent)})
+                      "subtask": bool(indent), "body": ""})
     return tasks
 
 

--- a/bin/worklog
+++ b/bin/worklog
@@ -95,6 +95,7 @@ def cmd_add(a):
     ev["set"] = {k: v for k, v in {
         "level": a.level, "kind": a.kind, "milestone": a.milestone,
         "title": a.title, "status": "todo", "priority": a.priority,
+        "body": a.body,
         "parent": a.parent, "plan": a.plan,
         "unplanned": True if a.unplanned else None,
         "discovered_during": a.discovered_during,
@@ -123,6 +124,7 @@ def cmd_update(a):
     ev = base(a.item, "update", a.actor)
     ev["set"] = {k: v for k, v in
                  {"status": a.status, "priority": a.priority, "title": a.title,
+                  "body": a.body,
                   "kind": a.kind, "milestone": a.milestone}.items()
                  if v is not None}
     if a.add_label:
@@ -343,6 +345,8 @@ def cmd_plan_capture(a):
     ev = base(epic_id, "create", a.actor)
     ev["set"] = {"level": "epic", "kind": "feature", "title": a.title,
                  "status": "todo", "priority": a.priority, "plan": path}
+    if a.body:
+        ev["set"]["body"] = a.body
     append(ev)
 
     item_ids, last_task = [], epic_id
@@ -355,6 +359,8 @@ def cmd_plan_capture(a):
                      "priority": t["priority"],
                      "parent": last_task if t["subtask"] else epic_id,
                      "plan": path}
+        if t.get("body"):
+            ev["set"]["body"] = t["body"]
         append(ev)
         item_ids.append(iid)
         if not t["subtask"]:
@@ -836,6 +842,8 @@ a.add_argument("--type", dest="legacy_type",
                help="DEPRECATED alias for --level/--kind (bug -> task/bug)")
 a.add_argument("--priority", default="P2", choices=["P0", "P1", "P2", "P3"])
 a.add_argument("--parent"); a.add_argument("--plan"); a.add_argument("--labels")
+a.add_argument("--body", help="description readable by a junior dev/PM: what "
+                              "and why, no ULIDs (spec §13.4)")
 a.add_argument("--unplanned", action="store_true")
 a.add_argument("--discovered-during", dest="discovered_during")
 
@@ -846,6 +854,8 @@ u.add_argument("--priority", choices=["P0", "P1", "P2", "P3"])
 u.add_argument("--title")
 u.add_argument("--kind", choices=list(KINDS))
 u.add_argument("--milestone")
+u.add_argument("--body", help="description readable by a junior dev/PM: what "
+                              "and why, no ULIDs (spec §13.4)")
 u.add_argument("--add-label", dest="add_label")
 u.add_argument("--del-label", dest="del_label")
 
@@ -904,6 +914,9 @@ pc.add_argument("--slug", required=True)
 pc.add_argument("--title", required=True)
 pc.add_argument("--file")
 pc.add_argument("--priority", default="P1", choices=["P0", "P1", "P2", "P3"])
+pc.add_argument("--body", help="epic description readable by a junior dev/PM "
+                               "(spec §13.4); task bodies come from plain "
+                               "lines under each task checkbox")
 
 rr = sub.add_parser("roadmap-render"); rr.set_defaults(fn=cmd_roadmap_render)
 rr.add_argument("--viz", default="deps,hierarchy",

--- a/docs/worklog-spec.md
+++ b/docs/worklog-spec.md
@@ -1,7 +1,9 @@
 # Worklog: Visible-WIP Work Tracking Spec
 
-**Version:** 1.8
+**Version:** 1.9
 **Status:** Implemented through §18 step 8; wiki publish (step 9) done for github-wiki; step 10 outstanding; step 11 (typed adapter contract) shipping; step 12 (work taxonomy) in progress on this branch
+
+**Changes since 1.8:** New §13.4 — ticket bodies must be readable by a junior dev or a PM (what + why, no ULIDs in the reading path); the `body` field is authored via `worklog add/update --body` and plain description lines under task checkboxes in `## Tasks`, and a marker-only ticket body is a policy violation. The field always existed in the canonical hash (§10.3) and sync path; 1.9 makes authoring it mandatory for skill-created items.
 
 **Changes since 1.7:** §4.2's `ticketing.system` / `wiki.system` enums widened to name what the skill path already reached — `github | gitlab | jira | ado | linear | codecatalyst | other | none` and `github-wiki | gitlab-wiki | ado-wiki | confluence | other | none`. The enum is explicitly **advisory**: `bin/worklog` branches only on `none` (invariant §15.6); every other value is a name the edge skills resolve to available tooling, and `other` is the sanctioned value for unlisted systems (real system named in `options:`). Known caveats ride with the names in the skills: AWS CodeCatalyst is closed to new customers since 2025-11-07 (existing spaces work); Linear has no git remote to detect (CLI/MCP evidence only); GCP has no native tracker, so no `gcp` value exists.
 
@@ -784,6 +786,21 @@ This is also *why* status reports can't be CI-hash-checked: step 2 isn't reprodu
 - **Needs attention** — open conflicts (§10.6), deferred syncs, failed pushes or publishes
 
 **The unplanned section is the point.** "38% of last week's closed items were unplanned, mostly interrupting PROJ-412" is the most useful number a team can have and almost nobody tracks it. It falls out of this schema for free — which is why `discovered_during` is required, not optional. `timecard` gets it as prose, not a percentage.
+
+### 13.4 Ticket bodies — readable by a junior dev or a PM
+
+The same audience rule as §13.1 applies to every synced ticket: the body a
+teammate sees in GitHub/Jira/ADO must say **what** the work is and **why it
+matters**, in one to three sentences of plain prose, with no ULIDs in the
+reading path. A ticket whose body is only a worklog marker is a policy
+violation — the marker is provenance, not a description.
+
+The `body` field carries this. It is set at authoring time (`worklog add
+--body`, `worklog update --body`, or plain lines under a task checkbox in a
+plan's `## Tasks` section), hashes canonically (§10.3), syncs both ways
+(§10.1), and renders below the idempotency marker in the ticket. Items
+created by skills MUST carry a body; the work-track and plan-capture skills
+state this rule to their authors.
 
 ---
 

--- a/plugin/scripts/plan_capture.py
+++ b/plugin/scripts/plan_capture.py
@@ -7,11 +7,13 @@ Pure functions only. All log writing happens in `worklog` (invariant 15.4).
 Task syntax, inside a `## Tasks` section of the draft:
 
     - [ ] (P1) Extract auth middleware
-      - [ ] Write failing test        <- indented = subtask of the task above
+      Plain lines under a task are its description -- written for a junior
+      dev or a PM: what and why, no ULIDs (spec section 13.4).
+      - [ ] Write failing test        <- indented checkbox = subtask
 
 `[x]` boxes count too (a captured plan may arrive partially done). Checkboxes
 outside the Tasks section are prose and are ignored. Priority token optional,
-default P2.
+default P2. Description lines attach to the most recent task as `body`.
 """
 import re
 
@@ -30,10 +32,14 @@ def parse_tasks(draft):
             continue
         m = TASK_RE.match(line)
         if not m:
+            if stripped and tasks:
+                prev = tasks[-1]
+                prev["body"] = (prev["body"] + "\n" + stripped
+                                if prev["body"] else stripped)
             continue
         indent, prio, title = m.groups()
         tasks.append({"title": title, "priority": prio or "P2",
-                      "subtask": bool(indent)})
+                      "subtask": bool(indent), "body": ""})
     return tasks
 
 

--- a/plugin/scripts/worklog
+++ b/plugin/scripts/worklog
@@ -95,6 +95,7 @@ def cmd_add(a):
     ev["set"] = {k: v for k, v in {
         "level": a.level, "kind": a.kind, "milestone": a.milestone,
         "title": a.title, "status": "todo", "priority": a.priority,
+        "body": a.body,
         "parent": a.parent, "plan": a.plan,
         "unplanned": True if a.unplanned else None,
         "discovered_during": a.discovered_during,
@@ -123,6 +124,7 @@ def cmd_update(a):
     ev = base(a.item, "update", a.actor)
     ev["set"] = {k: v for k, v in
                  {"status": a.status, "priority": a.priority, "title": a.title,
+                  "body": a.body,
                   "kind": a.kind, "milestone": a.milestone}.items()
                  if v is not None}
     if a.add_label:
@@ -343,6 +345,8 @@ def cmd_plan_capture(a):
     ev = base(epic_id, "create", a.actor)
     ev["set"] = {"level": "epic", "kind": "feature", "title": a.title,
                  "status": "todo", "priority": a.priority, "plan": path}
+    if a.body:
+        ev["set"]["body"] = a.body
     append(ev)
 
     item_ids, last_task = [], epic_id
@@ -355,6 +359,8 @@ def cmd_plan_capture(a):
                      "priority": t["priority"],
                      "parent": last_task if t["subtask"] else epic_id,
                      "plan": path}
+        if t.get("body"):
+            ev["set"]["body"] = t["body"]
         append(ev)
         item_ids.append(iid)
         if not t["subtask"]:
@@ -836,6 +842,8 @@ a.add_argument("--type", dest="legacy_type",
                help="DEPRECATED alias for --level/--kind (bug -> task/bug)")
 a.add_argument("--priority", default="P2", choices=["P0", "P1", "P2", "P3"])
 a.add_argument("--parent"); a.add_argument("--plan"); a.add_argument("--labels")
+a.add_argument("--body", help="description readable by a junior dev/PM: what "
+                              "and why, no ULIDs (spec §13.4)")
 a.add_argument("--unplanned", action="store_true")
 a.add_argument("--discovered-during", dest="discovered_during")
 
@@ -846,6 +854,8 @@ u.add_argument("--priority", choices=["P0", "P1", "P2", "P3"])
 u.add_argument("--title")
 u.add_argument("--kind", choices=list(KINDS))
 u.add_argument("--milestone")
+u.add_argument("--body", help="description readable by a junior dev/PM: what "
+                              "and why, no ULIDs (spec §13.4)")
 u.add_argument("--add-label", dest="add_label")
 u.add_argument("--del-label", dest="del_label")
 
@@ -904,6 +914,9 @@ pc.add_argument("--slug", required=True)
 pc.add_argument("--title", required=True)
 pc.add_argument("--file")
 pc.add_argument("--priority", default="P1", choices=["P0", "P1", "P2", "P3"])
+pc.add_argument("--body", help="epic description readable by a junior dev/PM "
+                               "(spec §13.4); task bodies come from plain "
+                               "lines under each task checkbox")
 
 rr = sub.add_parser("roadmap-render"); rr.set_defaults(fn=cmd_roadmap_render)
 rr.add_argument("--viz", default="deps,hierarchy",

--- a/plugin/skills/plan-capture/SKILL.md
+++ b/plugin/skills/plan-capture/SKILL.md
@@ -11,9 +11,14 @@ version: 0.12.1
        ## Tasks
 
        - [ ] (P1) Task title
+         One to three plain sentences under the checkbox become the task's
+         ticket body — written for a junior dev or a PM (spec §13.4):
+         what and why, no ULIDs.
          - [ ] Subtask of the task above
 
-   Priority token `(P0)`–`(P3)` optional, default P2. Prose (the *why*) goes
+   Priority token `(P0)`–`(P3)` optional, default P2. **Every task gets a
+   description line** — a marker-only ticket body is a policy violation
+   (§13.4). Prose (the *why*) goes
    in other sections and is preserved verbatim in the plan doc.
 
    Captured items are `kind:feature` by design — a plan's tasks deliver
@@ -22,7 +27,8 @@ version: 0.12.1
 
 2. Save it to a temp file and run:
 
-       bin/worklog plan-capture --slug <kebab-slug> --title "<plan title>" --file <tempfile>
+       bin/worklog plan-capture --slug <kebab-slug> --title "<plan title>" \
+           --body "<epic description a junior dev/PM can read>" --file <tempfile>
 
 3. Run `bin/worklog roadmap-render`, then commit `docs/plans/`,
    `docs/roadmap.md`, and `.work/todo.jsonl` together.

--- a/plugin/skills/work-track/SKILL.md
+++ b/plugin/skills/work-track/SKILL.md
@@ -16,9 +16,16 @@ only writer.
 
 ## Add an item
 
-    bin/worklog add "<title>" [--level epic|story|task|subtask] \
+    bin/worklog add "<title>" --body "<readable description>" \
+        [--level epic|story|task|subtask] \
         [--kind feature|bug|ops|triage] [--milestone v0.6.0] \
         [--priority P0-P3] [--parent <ulid>] [--labels a,b]
+
+**Every item gets a `--body` (spec §13.4).** One to three sentences a junior
+dev or a PM can read in the ticket: what the work is and why it matters. No
+ULIDs, no repo jargon in the reading path — the sync marker carries
+provenance, the body carries meaning. A ticket whose body is only a worklog
+id is a policy violation. Fix gaps with `worklog update <ulid> --body "..."`.
 
 Taxonomy rules (spec 5.4): epics are `feature` or `ops` only — kind is free
 at story/task/subtask; bugs may float free of any epic (`--parent` optional).

--- a/tests/test_plan_capture.py
+++ b/tests/test_plan_capture.py
@@ -15,6 +15,8 @@ Prose about why. Not a task:
 ## Tasks
 
 - [ ] (P0) Extract auth middleware
+  Move the token check into shared middleware so every route is covered.
+  Today each handler re-implements it and two forgot.
   - [ ] Write failing test
 - [x] Session store migration
 
@@ -42,6 +44,22 @@ class TestParseTasks(unittest.TestCase):
 
     def test_no_tasks_section_yields_nothing(self):
         self.assertEqual(parse_tasks("# Plan\n\n- [ ] loose checkbox\n"), [])
+
+    def test_plain_lines_under_a_task_become_its_body(self):
+        # Ticket bodies must be readable by a junior dev / PM (§13.4); the
+        # description travels as `body` on the task it follows.
+        tasks = parse_tasks(DRAFT)
+        self.assertEqual(
+            tasks[0]["body"],
+            "Move the token check into shared middleware so every route is "
+            "covered.\nToday each handler re-implements it and two forgot.")
+        self.assertEqual(tasks[1]["body"], "")  # subtask has no description
+
+    def test_body_lines_before_any_task_are_ignored(self):
+        draft = "## Tasks\n\nstray prose with no task yet\n- [ ] Real task\n"
+        tasks = parse_tasks(draft)
+        self.assertEqual([t["title"] for t in tasks], ["Real task"])
+        self.assertEqual(tasks[0]["body"], "")
 
 
 class TestFrontMatter(unittest.TestCase):


### PR DESCRIPTION
Synced tickets showed only the worklog marker and ULID — a PM or junior dev opening an issue couldn't tell what it was about (item 01KY5HGKCB, issue backfill already live on #91–#100).

## Changes
- `worklog add/update` and `plan-capture` gain `--body`; plan-capture attaches plain lines under a task checkbox as that task's description
- GitHub adapter `update` verb now pushes the body — it only pushed title+labels, so update-synced issues stayed marker-only forever (the second half of the root cause)
- Spec v1.9 adds §13.4: ticket bodies must be readable by a junior dev or a PM (what + why, no ULIDs); marker-only bodies are a policy violation
- work-track and plan-capture skills (repo + plugin mirrors) state the rule; plugin script copies synced
- Tests: parse_tasks description-line cases; full suite green (190 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BmURKwZz6bN6oMj1b4LBh