### PR TITLE
fix(compact): closed orphan aborts nightly compaction (verify mismatch)

### DIFF
--- a/bin/fold.py
+++ b/bin/fold.py
@@ -16,12 +16,15 @@ Read section 6 before changing anything in here. In particular:
 
 Taxonomy migration (docs/plans/2026-07-18-work-taxonomy.md section 3.2): the
 legacy single `type` field is a deprecated alias. On create/snapshot the fold
-normalizes it into (`level`, `kind`) and drops `type` from the ITEM (the event
-line is never touched). A create carrying neither type nor kind folds to
-kind:triage -- unclassified must look unclassified (section 2.3). This is
-LENIENT by design: the fold never crashes on a bad pair; hard validation
-lives at write time (CLI) and in the hook/CI check. Compaction snapshots the
-normalized state, so logs migrate physically at the next nightly run.
+maps it into (`level`, `kind`) and drops `type` from the ITEM (the event line
+is never touched). A create carrying neither type nor kind folds to
+kind:triage -- unclassified must look unclassified (section 2.3); that
+default is applied on `create` only, never on `snapshot` -- a snapshot must
+be a lossless round-trip of the state it was given (WORKLOG-SPEC section 7
+step 7), and defaulting there would fabricate taxonomy for items that were
+never created in the first place (e.g. a closed orphan). This is LENIENT by
+design: the fold never crashes on a bad pair; hard validation lives at write
+time (CLI) and in the hook/CI check.
 """
 
 import hashlib
@@ -43,17 +46,30 @@ LEGACY_TYPE_MAP = {
 }
 
 
-def _normalize_taxonomy(item: Dict[str, Any]) -> None:
+def _normalize_taxonomy(item: Dict[str, Any], defaults: bool = True) -> None:
     """Normalize a freshly created/snapshotted item to the (level, kind) model.
 
-    Lenient: unknown legacy types just fall through to the defaults
-    (level:task, kind:triage). Never raises.
+    Lenient: unknown legacy types just fall through. Never raises.
+
+    `defaults` controls whether a MISSING level/kind gets defaulted to
+    task/triage (spec 2.3: an unclassified create must still fold to
+    something). Only `create` wants that -- it is the one place a genuinely
+    new, never-before-seen item enters the fold. `snapshot` must stay a
+    lossless round-trip of whatever state it was given (compact.py writes
+    the folded state verbatim, WORKLOG-SPEC section 7 step 7): a snapshot of
+    an item that was itself never created (e.g. a closed orphan -- link/close
+    events for an id with no matching create) has no level/kind to begin
+    with, and re-fabricating defaults for it on every re-fold makes
+    compaction a non-idempotent transform and fails its own verify step.
+    Legacy `type` mapping still runs either way; that's real migrated data,
+    not an invented default.
     """
     t = item.pop("type", None)
     if t in LEGACY_TYPE_MAP and "level" not in item and "kind" not in item:
         item["level"], item["kind"] = LEGACY_TYPE_MAP[t]
-    item.setdefault("level", "task")
-    item.setdefault("kind", "triage")
+    if defaults:
+        item.setdefault("level", "task")
+        item.setdefault("kind", "triage")
 
 
 class FoldResult:
@@ -199,7 +215,7 @@ def fold(paths: Iterable[str] = ("todo.jsonl", "done.jsonl")) -> FoldResult:
             # watermark. Never merge into what's already there.
             item = {"id": iid}
             _apply_mutations(item, ev)
-            _normalize_taxonomy(item)
+            _normalize_taxonomy(item, defaults=False)
             result.items[iid] = item
             continue
 

--- a/plugin/scripts/fold.py
+++ b/plugin/scripts/fold.py
@@ -16,12 +16,15 @@ Read section 6 before changing anything in here. In particular:
 
 Taxonomy migration (docs/plans/2026-07-18-work-taxonomy.md section 3.2): the
 legacy single `type` field is a deprecated alias. On create/snapshot the fold
-normalizes it into (`level`, `kind`) and drops `type` from the ITEM (the event
-line is never touched). A create carrying neither type nor kind folds to
-kind:triage -- unclassified must look unclassified (section 2.3). This is
-LENIENT by design: the fold never crashes on a bad pair; hard validation
-lives at write time (CLI) and in the hook/CI check. Compaction snapshots the
-normalized state, so logs migrate physically at the next nightly run.
+maps it into (`level`, `kind`) and drops `type` from the ITEM (the event line
+is never touched). A create carrying neither type nor kind folds to
+kind:triage -- unclassified must look unclassified (section 2.3); that
+default is applied on `create` only, never on `snapshot` -- a snapshot must
+be a lossless round-trip of the state it was given (WORKLOG-SPEC section 7
+step 7), and defaulting there would fabricate taxonomy for items that were
+never created in the first place (e.g. a closed orphan). This is LENIENT by
+design: the fold never crashes on a bad pair; hard validation lives at write
+time (CLI) and in the hook/CI check.
 """
 
 import hashlib
@@ -43,17 +46,30 @@ LEGACY_TYPE_MAP = {
 }
 
 
-def _normalize_taxonomy(item: Dict[str, Any]) -> None:
+def _normalize_taxonomy(item: Dict[str, Any], defaults: bool = True) -> None:
     """Normalize a freshly created/snapshotted item to the (level, kind) model.
 
-    Lenient: unknown legacy types just fall through to the defaults
-    (level:task, kind:triage). Never raises.
+    Lenient: unknown legacy types just fall through. Never raises.
+
+    `defaults` controls whether a MISSING level/kind gets defaulted to
+    task/triage (spec 2.3: an unclassified create must still fold to
+    something). Only `create` wants that -- it is the one place a genuinely
+    new, never-before-seen item enters the fold. `snapshot` must stay a
+    lossless round-trip of whatever state it was given (compact.py writes
+    the folded state verbatim, WORKLOG-SPEC section 7 step 7): a snapshot of
+    an item that was itself never created (e.g. a closed orphan -- link/close
+    events for an id with no matching create) has no level/kind to begin
+    with, and re-fabricating defaults for it on every re-fold makes
+    compaction a non-idempotent transform and fails its own verify step.
+    Legacy `type` mapping still runs either way; that's real migrated data,
+    not an invented default.
     """
     t = item.pop("type", None)
     if t in LEGACY_TYPE_MAP and "level" not in item and "kind" not in item:
         item["level"], item["kind"] = LEGACY_TYPE_MAP[t]
-    item.setdefault("level", "task")
-    item.setdefault("kind", "triage")
+    if defaults:
+        item.setdefault("level", "task")
+        item.setdefault("kind", "triage")
 
 
 class FoldResult:
@@ -199,7 +215,7 @@ def fold(paths: Iterable[str] = ("todo.jsonl", "done.jsonl")) -> FoldResult:
             # watermark. Never merge into what's already there.
             item = {"id": iid}
             _apply_mutations(item, ev)
-            _normalize_taxonomy(item)
+            _normalize_taxonomy(item, defaults=False)
             result.items[iid] = item
             continue
 

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -167,5 +167,56 @@ class TestFileInvariants(CompactBase):
             self.assertEqual(marks, [MAX_EV], path)
 
 
+class TestTheBugThisPrevents(unittest.TestCase):
+    """Item 01KY5HW7KS / #101.
+
+    01KXSP277AE68GPTHC1QJV1NX is a one-character typo of a real epic id
+    (missing a `J`). It got a `link` event and a `close` event -- never a
+    `create` -- so the fold leaves it `_orphan: true` with no level/kind at
+    all: `_normalize_taxonomy` only defaults on `create`, and this id never
+    had one.
+
+    Before the fix, compact.py's snapshot builder wrote that orphan's folded
+    state verbatim (correctly, no level/kind) into a `snapshot` event -- but
+    `_normalize_taxonomy` ran unconditionally on every `snapshot` op when
+    re-folding to verify, injecting level:task/kind:triage into the
+    fold-of-new-logs that fold-of-old-logs never had. `fold(new) != fold(old)`
+    -> verify aborts -> compaction never advances the watermark.
+    """
+
+    def setUp(self):
+        d = tempfile.mkdtemp(prefix="worklog-compact-orphan-")
+        self.addCleanup(shutil.rmtree, d, True)
+        os.makedirs(os.path.join(d, ".work"))
+        self.todo = os.path.join(d, ".work", "todo.jsonl")
+        self.done = os.path.join(d, ".work", "done.jsonl")
+        write_log(self.todo, [
+            {"ev": "01B1", "ts": "t", "actor": "r",
+             "item": "01KXSP277AE68GPTHC1QJV1NX", "op": "link",
+             "set": {}, "add": {"labels": []}, "src": {"issue": 34}},
+            {"ev": "01B2", "ts": "t", "actor": "r",
+             "item": "01KXSP277AE68GPTHC1QJV1NX", "op": "close",
+             "set": {"status": "cancelled"}},
+        ])
+        write_log(self.done, [])
+
+    def test_closed_orphan_compacts_without_verify_failure(self):
+        # Would raise SystemExit(1) ("VERIFY FAILED") on the unfixed code.
+        compact(self.todo, self.done)
+
+    def test_closed_orphan_snapshot_invents_no_level_or_kind(self):
+        compact(self.todo, self.done)
+        item = fold([self.done]).items["01KXSP277AE68GPTHC1QJV1NX"]
+        self.assertEqual(item["status"], "cancelled")
+        self.assertNotIn("level", item)
+        self.assertNotIn("kind", item)
+
+    def test_fold_is_unchanged_by_compaction(self):
+        before = snap(fold([self.todo, self.done]))
+        compact(self.todo, self.done)
+        after = snap(fold([self.todo, self.done]))
+        self.assertEqual(before, after)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Symptom

Nightly `worklog-compact` has failed 3 nights running (07-20/21/22); watermark
stuck at 2026-07-19T07:59:27Z.

## Root cause

Item `01KXSP277AE68GPTHC1QJV1NX` is a one-character typo of the real epic
`01KXSP277AE68GPTJHC1QJV1NX` (missing `J`). It received a `link` event
(issue #34) and a `close` event on 2026-07-19, but never a `create`, so
`fold()` leaves it `_orphan: true` with no `level`/`kind` at all —
`_normalize_taxonomy` only defaults those on `create`, and this id never
had one.

`bin/compact.py` (spec §7 step 7) writes a `snapshot` event carrying that
orphan's folded state verbatim — correctly, with no level/kind — then
verifies by re-folding the new logs and comparing to the fold of the old
logs. The bug: `fold()`'s `snapshot` branch called `_normalize_taxonomy`
*unconditionally*, so re-folding the newly-written snapshot injected
`level: task, kind: triage` that the original fold never had. `fold(new) !=
fold(old)` → verify aborts → compaction never advances.

## Fix

`_normalize_taxonomy` in `bin/fold.py` gains a `defaults` flag. `create`
still defaults an unclassified item to `task`/`triage` (spec §2.3 —
unclassified must look unclassified, not silently disappear). `snapshot`
now only runs the legacy `type` → `level`/`kind` migration mapping and no
longer fabricates defaults for fields the folded item never had — making
compaction the no-op transform spec §7 requires. Real items are unaffected:
`create` already writes level/kind into the in-memory item, so every
snapshot of a legitimately-created item already carries them explicitly
regardless of this flag.

`plugin/scripts/fold.py` is the canonical copy synced via `cp bin/fold.py
plugin/scripts/fold.py` (test_plugin.py canon-sync check).

## Test plan

- [x] Added `TestTheBugThisPrevents` to `tests/test_compact.py`: a closed
      orphan (link + close, no create) compacts without a verify failure,
      and its compacted snapshot invents no `level`/`kind`.
- [x] Confirmed against the unfixed code path (traced by hand) that the
      added test reproduces `VERIFY FAILED` / `SystemExit(1)`.
- [x] `python3 -m pytest tests/ -q` → 193 passed.
- [x] Did not touch `.work/todo.jsonl` in this worktree — the nightly job
      exercises this fix against the real log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BmURKwZz6bN6oMj1b4LBh