### PR TITLE
#111: split document schema from entity schema — boundary refactor, zero behavior change

### DIFF
--- a/bin/ia.py
+++ b/bin/ia.py
@@ -27,22 +27,25 @@ LEDGER = ".work/published.json"
 INDEX_DIR = "docs/.index"
 INVENTORY = os.path.join(INDEX_DIR, "_inventory.json")
 
-DOC_TYPES = ("plan", "item", "roadmap", "roadmap-snapshot", "status",
+DOC_TYPES = ("plan", "roadmap", "roadmap-snapshot", "status",
              "design", "adr", "guide")
+# Graph/execution entities, not documents (schema/entity.schema.json).
+# Today only "item"; release and code-change join when they need validation.
+ENTITY_TYPES = ("item",)
 TRUTH_STATES = ("current", "snapshot", "superseded", "archived")
 EDGE_TYPES = ("produces", "decides", "implements", "supersedes",
               "verified-by", "lands-in", "belongs-to", "targets",
               "snapshot-of", "references")
 
-# Mirrors schema/doc.schema.json — same deliberate duplication as
-# adr.ADR_SCHEMA, so a scaffolded repo needs only bin/.
+# Mirrors schema/doc.schema.json + schema/entity.schema.json — same
+# deliberate duplication as adr.ADR_SCHEMA, so a scaffolded repo needs
+# only bin/.
 REQUIRED_ALL = ("wiki_key", "doc_type", "truth_state")
 REQUIRED_BY_TYPE = {
     # epic is NOT required: story-level plans float free (epic: null is
     # legitimate — see docs/plans/2026-07-19-adr.md)
     "plan": ("wiki_key", "doc_type", "title", "slug", "date", "truth_state",
              "status", "items"),
-    "item": ("wiki_key", "doc_type", "title", "status", "truth_state"),
     "roadmap": ("wiki_key", "doc_type", "truth_state", "generated_at"),
     "roadmap-snapshot": ("wiki_key", "doc_type", "truth_state", "date"),
     "status": ("wiki_key", "doc_type", "kind", "date", "window", "through",
@@ -51,6 +54,9 @@ REQUIRED_BY_TYPE = {
     "adr": ("wiki_key", "doc_type", "id", "slug", "title", "date", "status",
             "truth_state"),
     "guide": ("wiki_key", "doc_type", "title", "slug", "truth_state"),
+}
+REQUIRED_BY_ENTITY = {
+    "item": ("wiki_key", "doc_type", "title", "status", "truth_state"),
 }
 
 
@@ -419,13 +425,14 @@ def validate_record(rec):
     """Per-type required subset + enum checks -> list of problems."""
     problems = []
     t = rec.get("doc_type")
-    for f in REQUIRED_BY_TYPE.get(t, REQUIRED_ALL):
+    required = REQUIRED_BY_TYPE.get(t, REQUIRED_BY_ENTITY.get(t, REQUIRED_ALL))
+    for f in required:
         if f not in rec:
             problems.append("%s: missing %s" % (rec.get("source", "?"), f))
     if rec.get("truth_state") not in TRUTH_STATES:
         problems.append("%s: bad truth_state %r"
                         % (rec.get("source", "?"), rec.get("truth_state")))
-    if t not in DOC_TYPES:
+    if t not in DOC_TYPES and t not in ENTITY_TYPES:
         problems.append("%s: bad doc_type %r" % (rec.get("source", "?"), t))
     for edge in rec.get("relates_to") or []:
         if not isinstance(edge, dict) or "type" not in edge or "target" not in edge:

--- a/plugin/scripts/ia.py
+++ b/plugin/scripts/ia.py
@@ -27,22 +27,25 @@ LEDGER = ".work/published.json"
 INDEX_DIR = "docs/.index"
 INVENTORY = os.path.join(INDEX_DIR, "_inventory.json")
 
-DOC_TYPES = ("plan", "item", "roadmap", "roadmap-snapshot", "status",
+DOC_TYPES = ("plan", "roadmap", "roadmap-snapshot", "status",
              "design", "adr", "guide")
+# Graph/execution entities, not documents (schema/entity.schema.json).
+# Today only "item"; release and code-change join when they need validation.
+ENTITY_TYPES = ("item",)
 TRUTH_STATES = ("current", "snapshot", "superseded", "archived")
 EDGE_TYPES = ("produces", "decides", "implements", "supersedes",
               "verified-by", "lands-in", "belongs-to", "targets",
               "snapshot-of", "references")
 
-# Mirrors schema/doc.schema.json — same deliberate duplication as
-# adr.ADR_SCHEMA, so a scaffolded repo needs only bin/.
+# Mirrors schema/doc.schema.json + schema/entity.schema.json — same
+# deliberate duplication as adr.ADR_SCHEMA, so a scaffolded repo needs
+# only bin/.
 REQUIRED_ALL = ("wiki_key", "doc_type", "truth_state")
 REQUIRED_BY_TYPE = {
     # epic is NOT required: story-level plans float free (epic: null is
     # legitimate — see docs/plans/2026-07-19-adr.md)
     "plan": ("wiki_key", "doc_type", "title", "slug", "date", "truth_state",
              "status", "items"),
-    "item": ("wiki_key", "doc_type", "title", "status", "truth_state"),
     "roadmap": ("wiki_key", "doc_type", "truth_state", "generated_at"),
     "roadmap-snapshot": ("wiki_key", "doc_type", "truth_state", "date"),
     "status": ("wiki_key", "doc_type", "kind", "date", "window", "through",
@@ -51,6 +54,9 @@ REQUIRED_BY_TYPE = {
     "adr": ("wiki_key", "doc_type", "id", "slug", "title", "date", "status",
             "truth_state"),
     "guide": ("wiki_key", "doc_type", "title", "slug", "truth_state"),
+}
+REQUIRED_BY_ENTITY = {
+    "item": ("wiki_key", "doc_type", "title", "status", "truth_state"),
 }
 
 
@@ -419,13 +425,14 @@ def validate_record(rec):
     """Per-type required subset + enum checks -> list of problems."""
     problems = []
     t = rec.get("doc_type")
-    for f in REQUIRED_BY_TYPE.get(t, REQUIRED_ALL):
+    required = REQUIRED_BY_TYPE.get(t, REQUIRED_BY_ENTITY.get(t, REQUIRED_ALL))
+    for f in required:
         if f not in rec:
             problems.append("%s: missing %s" % (rec.get("source", "?"), f))
     if rec.get("truth_state") not in TRUTH_STATES:
         problems.append("%s: bad truth_state %r"
                         % (rec.get("source", "?"), rec.get("truth_state")))
-    if t not in DOC_TYPES:
+    if t not in DOC_TYPES and t not in ENTITY_TYPES:
         problems.append("%s: bad doc_type %r" % (rec.get("source", "?"), t))
     for edge in rec.get("relates_to") or []:
         if not isinstance(edge, dict) or "type" not in edge or "target" not in edge:

--- a/schema/doc.schema.json
+++ b/schema/doc.schema.json
@@ -1,12 +1,12 @@
 {
-  "$comment": "Unified doc frontmatter/sidecar schema (plan ia-content-model §5). Mirrored in bin/ia.py DOC_SCHEMA — same deliberate duplication as adr.schema.json / bin/adr.py. Per-type required subsets live in x-required-by-type (§5.4); the mini validator applies them to the merged record (frontmatter ∪ sidecar).",
+  "$comment": "Unified doc frontmatter/sidecar schema (plan ia-content-model §5) for documents — things people read (plan, roadmap, roadmap-snapshot, status, design, adr, guide). Graph/execution entities (today: item; release and code-change join later) live in schema/entity.schema.json instead. Mirrored in bin/ia.py DOC_SCHEMA — same deliberate duplication as adr.schema.json / bin/adr.py. Per-type required subsets live in x-required-by-type (§5.4); the mini validator applies them to the merged record (frontmatter ∪ sidecar).",
   "type": "object",
   "required": ["wiki_key", "doc_type", "truth_state"],
   "properties": {
     "wiki_key": {"type": "string"},
     "canonical_key": {"type": "string"},
     "aliases": {"type": "array", "items": {"type": "string"}},
-    "doc_type": {"enum": ["plan", "item", "roadmap", "roadmap-snapshot", "status", "design", "adr", "guide"]},
+    "doc_type": {"enum": ["plan", "roadmap", "roadmap-snapshot", "status", "design", "adr", "guide"]},
     "title": {"type": "string"},
     "slug": {"type": "string"},
     "truth_state": {"enum": ["current", "snapshot", "superseded", "archived"]},
@@ -53,7 +53,6 @@
   },
   "x-required-by-type": {
     "plan": ["wiki_key", "doc_type", "title", "slug", "date", "truth_state", "status", "items"],
-    "item": ["wiki_key", "doc_type", "title", "status", "truth_state"],
     "roadmap": ["wiki_key", "doc_type", "truth_state", "generated_at"],
     "roadmap-snapshot": ["wiki_key", "doc_type", "truth_state", "date"],
     "status": ["wiki_key", "doc_type", "kind", "date", "window", "through", "generated_at", "truth_state"],

--- a/schema/entity.schema.json
+++ b/schema/entity.schema.json
@@ -1,0 +1,29 @@
+{
+  "$comment": "Graph/execution entity schema (plan ia-content-model §5), split from schema/doc.schema.json (documents). Entities are things the graph tracks, not things people read: today only 'item' (work items, sidecar-overlaid onto the worklog fold); release and code-change join this enum when they need their own validation. Mirrored in bin/ia.py DOC_SCHEMA — same deliberate duplication as adr.schema.json / bin/adr.py. Per-type required subsets live in x-required-by-type (§5.4); the mini validator applies them to the merged record (fold ∪ sidecar).",
+  "type": "object",
+  "required": ["wiki_key", "doc_type", "truth_state"],
+  "properties": {
+    "wiki_key": {"type": "string"},
+    "canonical_key": {"type": "string"},
+    "aliases": {"type": "array", "items": {"type": "string"}},
+    "doc_type": {"enum": ["item"]},
+    "title": {"type": "string"},
+    "truth_state": {"enum": ["current", "snapshot", "superseded", "archived"]},
+    "status": {"type": "string"},
+    "relates_to": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "target"],
+        "properties": {
+          "type": {"enum": ["produces", "decides", "implements", "supersedes", "verified-by", "lands-in", "belongs-to", "targets", "snapshot-of", "references"]},
+          "target": {"type": "string"}
+        }
+      }
+    },
+    "code": {"type": ["object", "array", "string"]}
+  },
+  "x-required-by-type": {
+    "item": ["wiki_key", "doc_type", "title", "status", "truth_state"]
+  }
+}

--- a/tests/test_ia.py
+++ b/tests/test_ia.py
@@ -21,11 +21,11 @@ def run(cwd, *args):
 
 
 class TestSchemaSync(unittest.TestCase):
-    """schema/doc.schema.json and bin/ia.py are deliberate duplicates
-    (dependency-free bin/); this pins them equivalent so they cannot
-    silently diverge before the Phase 5 hard-fail promotion."""
+    """schema/doc.schema.json + schema/entity.schema.json and bin/ia.py are
+    deliberate duplicates (dependency-free bin/); this pins them equivalent
+    so they cannot silently diverge before the Phase 5 hard-fail promotion."""
 
-    def test_schema_json_matches_ia_constants(self):
+    def test_doc_schema_json_matches_ia_constants(self):
         with open(os.path.join(ROOT, "schema", "doc.schema.json")) as fh:
             schema = json.load(fh)
         props = schema["properties"]
@@ -37,6 +37,22 @@ class TestSchemaSync(unittest.TestCase):
             list(ia.EDGE_TYPES))
         self.assertEqual(schema["x-required-by-type"],
                          {k: list(v) for k, v in ia.REQUIRED_BY_TYPE.items()})
+
+    def test_entity_schema_json_matches_ia_constants(self):
+        with open(os.path.join(ROOT, "schema", "entity.schema.json")) as fh:
+            schema = json.load(fh)
+        props = schema["properties"]
+        self.assertEqual(schema["required"], list(ia.REQUIRED_ALL))
+        self.assertEqual(props["doc_type"]["enum"], list(ia.ENTITY_TYPES))
+        self.assertEqual(props["truth_state"]["enum"], list(ia.TRUTH_STATES))
+        self.assertEqual(
+            props["relates_to"]["items"]["properties"]["type"]["enum"],
+            list(ia.EDGE_TYPES))
+        self.assertEqual(schema["x-required-by-type"],
+                         {k: list(v) for k, v in ia.REQUIRED_BY_ENTITY.items()})
+
+    def test_doc_and_entity_types_are_disjoint(self):
+        self.assertEqual(set(ia.DOC_TYPES) & set(ia.ENTITY_TYPES), set())
 
 
 class TestParsing(unittest.TestCase):


### PR DESCRIPTION
## The big picture

WikiTicket SDD tracks work in an append-only event log (`.work/todo.jsonl`) and publishes the derived truth — plans, roadmap, status reports, ADRs — to a GitHub wiki. The IA & content model epic (#93, shipped in PR #104) gave every published document a stable identity (`wiki_key`), a formal frontmatter schema, and a truth banner (current vs. historical). Post-merge, two independent technical reviews audited that work; their findings became tickets #109–#111:

    Step 1: Repair frozen-plan drift on the Grok viz plan          — #109, shipped on main (d5b442d)
    Step 2: Pin schema/doc.schema.json ≡ bin/ia.py with a test     — #110, shipped on main (d5b442d)
    Step 3: Split document schema from entity schema               — #111   <== THIS PR
    Step 4: Promote IA gates to hard-fail after warn cycle         — #98, deferred by design

**Domain terms:** a *document* is something people read (plan, roadmap, status report, ADR, design, guide) — it has frontmatter or a *sidecar* (metadata file under `docs/.index/`, used so frozen documents are never edited). An *entity* is something the traceability graph tracks but nobody reads as a page: today only `item` (a work item from the event log); releases and code-changes are future entities. The *fold* is the derived state of the event log; the *CANON invariant* means every file in `bin/` is byte-identical to its `plugin/scripts/` copy.

## Who actually calls this

`bin/ia.py` is imported by the `worklog` CLI (`ia-normalize`, `ia-inventory`, `ia-index`) — run by humans, by AI agents following repo skills, and by the pre-commit hook (currently warn-only). The two JSON schema files are the published contract; the Python constants are the runtime validator. Nothing here runs with elevated permissions and nothing publishes on its own.

## The problem this PR solves

Review finding 4 on PR #104 (recorded as #111): the unified `schema/doc.schema.json` listed `item` alongside plan/roadmap/ADR/etc. That boundary is conceptually wrong and practically misleading:

1. Documents are read artifacts with frontmatter/sidecars; items are execution entities whose state is owned by the event-log fold. One schema implied they share a lifecycle — they don't.
2. Future graph entities (release, code-change) would each have worsened the mismatch, or been wedged into a "doc" schema they aren't.
3. The reviewer's advice: split when convenient, before a second entity arrives — small now, painful later.

## Scope

Exactly the ticket's ask: draw the schema boundary, change zero validation behavior. Every record that validated before validates identically after, with identical error messages. In scope: the two schema files, the mirrored constants in `bin/ia.py`, the drift tests. Out of scope: item-sidecar validation itself (doesn't exist yet — `item` records are synthesized only as graph nodes by `bin/ia_graph.py`, which never calls the validator), any rename of the `doc_type` record field (that would be a behavior change), and new entity types.

## What exactly was changed

- `schema/doc.schema.json` — `item` removed from the `doc_type` enum and from `x-required-by-type`; `$comment` now states the document/entity boundary and points to the new file.
- `schema/entity.schema.json` (new) — same hand-written house style; enum `["item"]` with a comment noting release/code-change join when they need validation; the `item` required subset moved here verbatim (`wiki_key, doc_type, title, status, truth_state`); only the fields an item overlay can carry (identity, status, `relates_to` edges, `code` evidence).
- `bin/ia.py` — `DOC_TYPES` loses `item`; new `ENTITY_TYPES = ("item",)` and `REQUIRED_BY_ENTITY`; `validate_record` consults the union (`REQUIRED_BY_TYPE.get(t, REQUIRED_BY_ENTITY.get(t, REQUIRED_ALL))`, and bad-doc_type checks both tuples). The mirror comment now names both schema files. The duplication between JSON and Python is deliberate (a scaffolded repo needs only `bin/`) and is what the drift tests pin.
- `plugin/scripts/ia.py` — byte-identical copy (CANON invariant, enforced by `tests/test_plugin.py`).
- `tests/test_ia.py` — `TestSchemaSync` now pins both files independently: doc schema ↔ doc constants, entity schema ↔ entity constants, plus a new assertion that the two enums are disjoint (a type can never be both).

`docs/.index/**` needed no regeneration: `item` never appeared in the on-disk inventory, so the derived artifacts are byte-identical before and after — itself evidence the split changes no behavior.

## How it was tested

Full suite: **245 passed** (was 243; +2 new schema-sync tests), run in the implementation worktree and re-verified before push. `bin/worklog ia-index` runs clean with no diff. Not separately tested: a live `item` record flowing through `validate_record` — no current code path constructs one (see scope); the union logic exists to keep the contract correct for the future caller, and the disjointness test guards the enums until then. CI (`worklog-invariants`, includes the ≥80% coverage floor) gates the merge.

## Deliberately out of scope

- Item-sidecar validation wiring (arrives with the first real consumer).
- `release` / `code-change` entity types — they join `entity.schema.json` when something needs to validate them.
- Gate hard-fail promotion and platform adapters (#98, waiting out the warn cycle per the plan).

## Ticket glossary

| Ticket | What it is | Status |
|--------|------------|--------|
| #93 | Epic: IA & content model | Open (only #98 remains) |
| #104 | PR that shipped IA Phases 0–4 | Merged |
| #109 | Frozen-plan drift repair (review finding 1) | Closed, shipped on main |
| #110 | Schema↔validator drift test (review finding 5) | Closed, shipped on main |
| #111 | This PR — document/entity schema split (review finding 4) | In progress |
| #98 | Phase 5: gate promotion, adapters, /worklog:find | Open, deferred by design |

Worklog item: `01KY5QV5G05V77TKESCJVY62S3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bQhVDhmHh3MwFP59sAX8t
