### PR TITLE
docs: sync README + plugin guide for v0.16.0 integration-guide skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ of stuff last week and nobody knows what."
   per ticket, PR, and release (`worklog ia-ticket <ULID>` to preview one).
 - **Syncs to the team's OWN systems** — wiki *and* tickets. Your work log
   publishes to whatever your team already uses.
+- **Living integration guides**, one per SDD tool and ticket/wiki system
+  (Superpowers, GSD, SpecKit, OpenSpec, Jira, Confluence, GitHub, GitLab,
+  Azure DevOps, AWS CodeCatalyst, Google Cloud DevOps), fetched from the
+  wiki at runtime with a local fallback under `docs/integrations/` — see the
+  `integration-guide` skill.
 
 ## System-agnostic edges, deliberately
 
@@ -50,10 +55,14 @@ GCP-hosted teams pick from the list like everyone else.)
 
 The core never contains per-system code. Publishing and sync are done by
 *skills* that instruct the AI to use whatever CLI, MCP server, or skill is
-available for the chosen system, researching missing tooling at runtime.
-LLMs already know these systems well; shipping a repository of per-system
-integrations would be dead weight. You could even run two trackers at once
-(GitHub + Jira) — the workflow stays identical.
+available for the chosen system, researching missing tooling at runtime. The
+`integration-guide` skill points at a living, wiki-hosted setup guide per
+system (Jira, Confluence, GitHub, GitLab, Azure DevOps, AWS CodeCatalyst,
+Google Cloud DevOps — plus Superpowers, GSD, SpecKit, and OpenSpec on the SDD
+side), with a local fallback copy under `docs/integrations/` when the wiki
+page is unreachable — knowledge that lives in docs, not hard-coded into the
+skill set. You could even run two trackers at once (GitHub + Jira) — the
+workflow stays identical.
 
 ## Quick start (no plugin)
 
@@ -166,8 +175,9 @@ is in [docs/worklog-spec.md](docs/worklog-spec.md). Task-oriented guides
 | `docs/designs/` | Current + frozen design docs and code walkthroughs |
 | `docs/.index/` | IA inventory, graph, publish manifest, sidecars, rendered Home/Sidebar/indexes |
 | `docs/user_guide/` | User guide, CLI reference, plugin guide |
+| `docs/integrations/` | Living per-system setup guides (11 SDD tools + ticket/wiki systems), published to the wiki and used as the `integration-guide` skill's offline fallback |
 | `hooks/` | `pre-commit`, `pre-merge-commit`, `commit-msg`, `exit-plan-capture.sh` |
-| `plugin/` | The Claude Code plugin (manifest, commands, skills, hooks, canonical scripts) — **v0.15.0** |
+| `plugin/` | The Claude Code plugin (manifest, commands, skills, hooks, canonical scripts) — **v0.16.0** |
 | `tests/` | Unit and integration tests |
 
 ## Testing

--- a/docs/user_guide/plugin-guide.md
+++ b/docs/user_guide/plugin-guide.md
@@ -103,6 +103,7 @@ Skills are the judgment layer: the model decides *when*, the deterministic
 | `design-docs` | Generates/syncs the design doc + code walkthrough pair under `docs/designs/`: frozen dated copies per release, live `current` copies; runs in background agents at release time |
 | `merge-green` | Merges PRs only when every quality gate is green — polls every 5 minutes via `merge-when-green.sh`, never bypasses |
 | `classify` | Flag-gated classifier: sweeps a conversation for untracked work, propose-only into `.work/suggestions.jsonl` — never the event log |
+| `integration-guide` | Looks up the wiki-hosted setup guide for a named SDD tool or ticket/wiki system (Superpowers, GSD, SpecKit, OpenSpec, Jira, Confluence, GitHub, GitLab, Azure DevOps, AWS CodeCatalyst, Google Cloud DevOps), falling back to the local copy under `docs/integrations/` on fetch failure |
 
 ## The hooks
 


### PR DESCRIPTION
## Summary

v0.16.0 (tag `v0.16.0`, commit `60f5605`) shipped the new `integration-guide`
skill plus 11 wiki-hosted integration pages under `docs/integrations/` and a
meta index — a mechanism for pointing users at living setup guides for SDD
tools (Superpowers, GSD, SpecKit, OpenSpec) and ticket/wiki systems (Jira,
Confluence, GitHub, GitLab, Azure DevOps, AWS CodeCatalyst, Google Cloud
DevOps) instead of hard-coding that knowledge into the skill set. Per the
release skill's Agent B doc-sync step, this PR brings `README.md` and
`docs/user_guide/plugin-guide.md` back in line with that diff — nothing else
was touched.

- `docs/user_guide/plugin-guide.md`: the skills table listed 12 skills, not
  the new 13th. Added the `integration-guide` row, matching the exact
  precedent set when `design-docs`/`merge-green`/`classify` were added
  (new skill → one appended row, description lifted from its `SKILL.md`).
- `README.md`:
  - The "System-agnostic edges, deliberately" section stated "shipping a
    repository of per-system integrations would be dead weight" — this
    release does exactly that (`docs/integrations/`), so the claim is now
    false. Reworded to describe the actual mechanism (wiki-hosted guide +
    local fallback) without over-claiming.
  - Added a "What it does" bullet for the new integration-guide feature,
    matching the style of the existing design-docs bullet added in the
    same spot for a prior release.
  - Added a `docs/integrations/` row to the Layout table, alongside the
    other `docs/*` rows.
  - Bumped the `plugin/` row's version marker from **v0.15.0** to
    **v0.16.0**, matching the existing per-minor-release bump pattern
    (v0.13.0 → v0.14.0 → v0.15.0 in prior release PRs).

No other user-facing docs needed changes — the `trace-check`/evidence-link
cleanup and version-bump housekeeping in this release aren't user-facing,
and `ticket-sync/SKILL.md` / `wiki-publish/SKILL.md` were deliberately left
unedited by the integration-guide plan itself (see
`docs/plans/2026-07-25-wiki-driven-integration-guides.md`, "Explicitly out
of scope").

## Test plan

- [x] Diff reviewed against `v0.15.1..v0.16.0` diff and prior-release
      doc-sync precedent (`git log` on `plugin-guide.md`/`README.md`)
- [ ] CI green (merge-when-green will confirm)

Refs work item `01KYDZRVN5HAP73465JAM65EK7` (Release v0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141heNaVWfXFGJ8ze3x74tc