### PR TITLE
docs: publish declare-graph-engineering plan to wiki

### DIFF
--- a/.work/published.json
+++ b/.work/published.json
@@ -3384,6 +3384,19 @@
     "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Plan-wiki-driven-integration-guides",
     "wiki_key": "plan/2026-07-25-wiki-driven-integration-guides"
   },
+  "plan/2026-07-26-declare-graph-engineering": {
+    "canonical_key": "plan/2026-07-26-declare-graph-engineering",
+    "doc_type": "plan",
+    "page_id": "Plan-declare-graph-engineering",
+    "render_hash": "54e7ca57d1bd",
+    "rev": "cec973f92a2283c9852c3584836de5422b72a064",
+    "source": "docs/plans/2026-07-26-declare-graph-engineering.md",
+    "source_hash": "becabcd86332",
+    "title": "Declare wiki_ticket_sdd as a Graph Engineering system",
+    "truth_state": "current",
+    "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Plan-declare-graph-engineering",
+    "wiki_key": "plan/2026-07-26-declare-graph-engineering"
+  },
   "plan/design-docs-release-sync": {
     "aliases": [
       "plan/design-docs-release-sync"


### PR DESCRIPTION
## Summary
- Publishes the newly captured plan `docs/plans/2026-07-26-declare-graph-engineering.md` (epic 01KYFSRNDMYCTQ1XTMXFWEVBWT) to the wiki as `Plan-declare-graph-engineering` (wiki commit cec973f).
- Records the ledger entry `plan/2026-07-26-declare-graph-engineering` in `.work/published.json` per the wiki-publish skill (source_hash/render_hash from the publish manifest).

No other files touched — kept isolated in its own worktree/branch off `origin/main` so it doesn't collide with in-progress work on `docs/graph-engineering-plan-capture`.

## Test plan
- [x] Wiki page pushed and viewable at https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Plan-declare-graph-engineering
- [x] `.work/published.json` diff is a single new, well-formed entry (verified via `git diff`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_0141heNaVWfXFGJ8ze3x74tc