### PR TITLE
docs: user guide refresh for v0.18.0 (one-owner rule, unlink)

### DIFF
--- a/docs/.index/publish-manifest.json
+++ b/docs/.index/publish-manifest.json
@@ -3724,7 +3724,7 @@
    "frozen": false,
    "page_name": "User-Guide",
    "render": "doc+banner",
-   "render_hash": "fa53af628677",
+   "render_hash": "96c2837e200f",
    "source": "docs/user_guide/user-guide.md",
    "title": "WikiTicket SDD \u2014 User Guide",
    "truth_state": "current",

--- a/docs/user_guide/user-guide.md
+++ b/docs/user_guide/user-guide.md
@@ -60,11 +60,13 @@ Every event and every item gets a ULID — a sortable, timestamp-prefixed
 unique ID like `01J8X0M2QQ...`. Sorting events by ULID sorts them by time, so
 the fold is a plain string sort, deterministic on every machine. The ULID is
 the item's primary key forever; external ticket keys (like `PROJ-412`) are
-just linked identity.
+just linked identity — and that link runs one way only: **one remote ticket
+has exactly one local owner.** `link` refuses a key another item already
+holds (even a cancelled one), and `unlink` is the supported undo.
 
 You rarely type all 26 characters. Every command that names an existing item
-(`update`, `close`, `link`, `reopen`, `resolve`, `show`) takes any unambiguous
-prefix — paste the short id `worklog list` and `worklog show` print. A prefix
+(`update`, `close`, `link`, `unlink`, `reopen`, `resolve`, `show`) takes any
+unambiguous prefix — paste the short id `worklog list` and `worklog show` print. A prefix
 that matches two items is refused and the candidates are named; a prefix that
 matches nothing is refused and nothing is written.
 
@@ -373,9 +375,10 @@ never fails a command.
 ## Sync in depth
 
 Ticket sync (`bin/worklog sync`) runs through a typed adapter contract. The
-dispatcher (`bin/sync_dispatch.py`) owns every invariant — scope, canonical
-hash-skip, create-vs-update, idempotency markers, echo suppression on pull,
-conflict detection — and a per-system adapter is a generated dumb
+dispatcher (`bin/sync_dispatch.py`) owns every invariant — scope, change
+detection (the canonical hash *and* the ticket the item last pushed to),
+one-owner-per-ticket, create-vs-update, idempotency markers, echo suppression
+on pull, conflict detection — and a per-system adapter is a generated dumb
 translator that just maps canonical JSON to the platform's API and back.
 `worklog adapter check` gates any adapter: nothing activates until it
 validates green against the contract, and a missing adapter means the
@@ -384,6 +387,14 @@ drift report — counts plus anything a human should see (conflicts,
 unsupported fields, deferred items). That report is the sync's voice; read
 it. Conflicts it detects are resolved with
 `bin/worklog resolve <item> --field <f> --take local|remote`.
+
+One thing does not go in the drift report: a ticket claimed by more than one
+item. Sync refuses to push *those* items (corruption needs both of them
+pushed), finishes the rest of the run, prints the claimants and the repair as
+its own block, and **exits non-zero** — under `--dry-run` too. The repair
+ends with `worklog sync --keys <key>`, because unlinking the impostor does not
+by itself make the surviving owner dirty enough to re-push over the damage.
+See the [CLI Reference](cli-reference.md#unlink).
 
 Remote ticket **bodies** are composed from the local source via
 `bin/worklog ticket-body <ulid>` (issue-description skill): summary,


### PR DESCRIPTION
## What this is

Step 5 of the v0.18.0 release doc-sync (`release.sync_docs`), the `user-guide`
and `readme` targets. Work item `01KYNKBCNS8WY5BH2B7EDBHMF1`.

v0.18.0 shipped the one-owner-per-external-key fix (github#226), the new
`worklog unlink` subcommand, key-aware sync change detection, and the GitHub
adapter's single-call create (github#235). `docs/user_guide/cli-reference.md`
was already updated inside the #226 PR. This PR closes the gap the rest of the
user-facing docs still had, and nothing more.

## What changed

`docs/user_guide/user-guide.md`, two places:

- **ULIDs section.** The list of commands that accept an unambiguous id prefix
  omitted `unlink`, which resolves prefixes exactly like the other six
  (`cmd_unlink` calls `_resolve`). Also states the one-owner rule where the
  guide introduces external keys as "just linked identity" — that link is now
  exclusive, `link` refuses a key another item holds (cancelled owners
  included), and `unlink` is the supported undo.
- **Sync in depth.** The dispatcher-invariant list said "canonical hash-skip",
  which is no longer the whole change-detection rule: `is_dirty` now also
  compares `last_pushed_key`, so an unlink or re-link is no longer a silent
  no-op at sync time. Added the one-owner gate to that list, and a short
  paragraph on contested tickets — deliberately printed *outside* the drift
  report, skipping only the claimants, exiting non-zero including under
  `--dry-run`, with the `sync --keys <key>` step people otherwise miss.

`docs/.index/publish-manifest.json` — regenerated `render_hash` for the
User-Guide page (one line), so the page republishes.

## What was checked and deliberately left alone

- **README.md** — the plugin version marker in the layout table already reads
  **v0.18.0** (stamped in the release commit). Its sync/adapter prose
  ("typed adapter contract", `worklog adapter check` gating) is unchanged by
  this release. No edit.
- **docs/user_guide/cli-reference.md** — verified line by line against the
  shipped code rather than rewritten: the `unlink` scope table (open → new
  ticket via `is_dirty`; closed with no key → inert via the scope guard), the
  `link` refusal text, the ambiguous-prefix message, the contested-ticket
  block, and the worktree note about an absolute `core.hooksPath` (which
  `doctor.sh` accepts). All accurate. No edit.
- **docs/user_guide/plugin-guide.md** — documents slash commands and skills,
  not CLI subcommands, so `unlink` does not belong there. No edit.
- **GitHub adapter (github#235)** — no user-facing doc describes how create
  calls the API, so the REST switch made nothing stale.

## Testing

`python3 -m pytest tests -q` — **307 passed**, run in an isolated worktree off
`origin/main`.