### PR TITLE
chore(wiki): publish the v0.20.0 tail — 3 pages

### DIFF
--- a/.work/published.json
+++ b/.work/published.json
@@ -453,10 +453,10 @@
   },
   "index/traceability": {
     "page_id": "Index-Traceability",
-    "render_hash": "8e90c5b3b5e1",
-    "rev": "4ace2032c46f5520070091cc00877603fa8e7b3e",
+    "render_hash": "7231594204b9",
+    "rev": "04d97f3f078906cdb740b8ce1a5f5640e6e9ebaa",
     "source": "docs/.index/rendered/traceability.md",
-    "source_hash": "8e90c5b3b5e1",
+    "source_hash": "7231594204b9",
     "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Index-Traceability"
   },
   "integrations/awscodecatalyst": {
@@ -3977,6 +3977,14 @@
     "source_hash": "2a88c4e720eb",
     "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Ticket-01KZ2MZ69SFQDHEXFBJTXTDNFX"
   },
+  "item/01KZ2PJZF067ZS4YW231C1FM28": {
+    "page_id": "Ticket-01KZ2PJZF067ZS4YW231C1FM28",
+    "render_hash": "9a6ffd001273",
+    "rev": "04d97f3f078906cdb740b8ce1a5f5640e6e9ebaa",
+    "source": "docs/.index/rendered/tickets/01KZ2PJZF067ZS4YW231C1FM28.md",
+    "source_hash": "9a6ffd001273",
+    "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Ticket-01KZ2PJZF067ZS4YW231C1FM28"
+  },
   "plan/2026-07-17_worklog-core_plan": {
     "canonical_key": "plan/2026-07-17_worklog-core_plan",
     "doc_type": "plan",
@@ -4746,10 +4754,10 @@
     "canonical_key": "roadmap",
     "doc_type": "roadmap",
     "page_id": "Roadmap",
-    "render_hash": "c5f5034c4651",
-    "rev": "4ace2032c46f5520070091cc00877603fa8e7b3e",
+    "render_hash": "66e83106dfe7",
+    "rev": "04d97f3f078906cdb740b8ce1a5f5640e6e9ebaa",
     "source": "docs/roadmap.md",
-    "source_hash": "2585aaffd4c5",
+    "source_hash": "3b56d499ad3f",
     "truth_state": "current",
     "url": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd/wiki/Roadmap",
     "wiki_key": "roadmap"


### PR DESCRIPTION
Ledger update for wiki commit `04d97f3`. Three pages: the roadmap, the traceability index, and one ticket page. **Manifest and ledger now agree completely — 0 pages unpublished.**

These became publishable because the publish itself filed a work item (the release-note correction owed to the next release), which regenerated the roadmap and traceability index.

Worth naming rather than leaving as a curiosity: **recording work about a publish changes the pages that publish produced.** It converges after one round only because publishing is not itself tracked work. Anyone adding a worklog write to the publish path should know the loop is one step from being unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeNyeCF8Wfe98Drk1YY5kR