### PR TITLE
feat: Cursor host support (worklog 0.24.2)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,11 +1,9 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "worklog",
   "version": "0.24.2",
   "description": "WikiTicket SDD (worklog): git-native plans, tickets, roadmaps, and wiki publishing. Multi-host bindings plus worklog-vs-knowledge isolation.",
   "author": {
-    "name": "Rick Hightower",
-    "url": "https://github.com/RichardHightower"
+    "name": "Rick Hightower"
   },
   "homepage": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd",
   "repository": "https://github.com/SpillwaveSolutions/wiki_ticket_sdd",
@@ -20,6 +18,9 @@
     "codex",
     "deep-agents",
     "grok-bot",
-    "cursor"
-  ]
+    "cursor",
+    "second-brain"
+  ],
+  "skills": ".claude/skills/",
+  "rules": ".cursor/rules/"
 }

--- a/.cursor/rules/second-brain.mdc
+++ b/.cursor/rules/second-brain.mdc
@@ -1,0 +1,16 @@
+---
+description: Second-brain write protocol for Cursor agents (Grok Bot coding host)
+alwaysApply: true
+---
+
+You are reading and writing a shared OKF second brain.
+
+1. Claim an identity first (`SECOND_BRAIN_IDENTITY` or `--author`). Anonymous writes are forbidden.
+2. Pack first (2 hops, token budget). Do not dump the tree into chat.
+3. Writes go through the pack scripts only. Never write raw Markdown into `knowledge/`.
+4. Isolate: `python3 scripts/brain_session.py open` then write then `close` (PR). Do not commit on `main`.
+5. Pack roots (`--root /clients/<slug>.md`) are packing hints, not access control.
+6. Never name, link, or clone-instruct a private remote. Knowledge root is `SECOND_BRAIN_ROOT` or a path the human already owns.
+7. Public samples stay Northstar / Lumenfield. No live client facts in public packs.
+8. If this checkout is a knowledge tree (not the plugin repo), still use the pack scripts when present. If they are missing, stop and ask — do not invent a write path.
+9. Restricted types honor the pack `actors.json` allowlist when present (DailyDigest is CoS-only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.24.2 — 2026-08-17
+
+- **Cursor host.** `.cursor-plugin/plugin.json` (Cursor Plugins) plus `.cursor/rules/second-brain.mdc`. Docs: `docs/CURSOR.md`. `docs/GROK_BOT.md` now covers Grok Bot spawning Cursor cloud agents.
+

--- a/docs/CURSOR.md
+++ b/docs/CURSOR.md
@@ -1,0 +1,71 @@
+# Cursor — binding this ContentPack
+
+Cursor is a first-class host. Grok Bot uses Cursor cloud agents for reads
+and writes against the knowledge tree. Local Cursor can load this pack as
+a plugin.
+
+This is **not** a second copy of the skills. Same `skills/`, same scripts,
+same isolation protocol.
+
+## How Cursor loads this pack
+
+Cursor has four layers. We use the first three. We do not ship per-pack MCP.
+
+| Layer | What we ship | Where |
+|-------|----------------|-------|
+| Agent Skills | Existing `SKILL.md` files | `skills/` (also `.claude/skills/` on worklog) |
+| Agent Plugins 1.0 | Root `plugin.json` | repo root |
+| Cursor Plugins | Rules + skill pointer | `.cursor-plugin/plugin.json` |
+| MCP | Not in this pack | deferred |
+
+Cursor also reads `.claude/skills/` and `.codex/skills/` for compatibility.
+
+## Install (local Cursor)
+
+```text
+/plugin marketplace add SpillwaveSolutions/second-brain-marketplace
+/plugin install worklog
+```
+
+Or open this repo and load it as a local plugin (`--plugin-dir` / Customize).
+
+Root `plugin.json` already declares the Agent Plugins 1.0 schema, so Cursor
+loads skills without a rewrite.
+
+## Cloud Cursor (the Grok Bot hole)
+
+A Grok Bot coding session usually opens **the knowledge tree**, not this
+plugin repo. The cloud agent sees `AGENTS.md` and pack scripts if they are
+vendored there. It does **not** see your local Claude or Grok plugin cache.
+
+Do this:
+
+1. Claim identity (`SECOND_BRAIN_IDENTITY` or `--author`).
+2. Pack first (2 hops). Do not dump the tree.
+3. Write only through the pack script. No raw Markdown into `knowledge/`.
+4. Isolate: `brain_session.py open` → write → `close` (PR).
+5. Never invent a private remote.
+
+The knowledge tree should carry `AGENTS.md` and, if you want skills without
+a plugin install, `.agents/skills/` shims. That binding lives in the tree
+the human already owns — not in this public pack.
+
+## Rules
+
+`.cursor/rules/second-brain.mdc` is always-on when this repo is the Cursor
+workspace. It restates identity, pack-first, scripted writes, isolation,
+and the privacy fence.
+
+## Identity
+
+Actor: `grok-bot/worklog`
+Host flag on session open: `--host cursor`
+
+Same owned types as [GROK_BOT.md](GROK_BOT.md). Same privacy fence.
+
+## Related
+
+- [GROK_BOT.md](GROK_BOT.md) — Grok Bot binding (now includes Cursor)
+- [ISOLATION.md](ISOLATION.md) — worktree + PR
+- [https://cursor.com/docs/plugins](https://cursor.com/docs/plugins)
+- [https://agent-plugins.org](https://agent-plugins.org)

--- a/docs/GROK_BOT.md
+++ b/docs/GROK_BOT.md
@@ -78,6 +78,16 @@ Worklog appends do not require a knowledge worktree. Knowledge-tree writes do.
 | Working | Current turn + packed context |
 | Institutional | The private OKF Markdown tree |
 
+## Cursor (Grok Bot coding host)
+
+Grok Bot often opens a **Cursor cloud agent** against the knowledge tree.
+That session does **not** automatically have this plugin installed.
+
+- Local Cursor: add the marketplace, then install this plugin. See [CURSOR.md](CURSOR.md).
+- Cloud Cursor on the brain: follow this file plus `AGENTS.md` in the knowledge tree. Plugin install is optional. The write protocol is not.
+- This pack ships `.cursor-plugin/plugin.json` (Cursor Plugins) and a root `plugin.json` (Agent Plugins 1.0). Cursor loads both. Skills stay in `skills/`.
+- Never name a private remote. Pack roots are packing hints, not access control.
+
 ## Related public packages
 
 ### Foundation layer

--- a/hosts/cursor/SKILL.md
+++ b/hosts/cursor/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: cursor-worklog
+description: Bind a Cursor agent (including Grok Bot cloud sessions) to the worklog ContentPack.
+---
+
+# Cursor / worklog
+
+Follow `docs/CURSOR.md` and `docs/GROK_BOT.md`.
+
+1. Identity: `grok-bot/worklog` (or the operator-registered actor for this role).
+2. Local Cursor may `/plugin install worklog` from the Spillwave marketplace.
+3. Cloud Cursor on a knowledge tree: pack first, write only via pack scripts, isolate with `brain_session.py`.
+4. Never document a private remote. Never write raw Markdown into the tree.


### PR DESCRIPTION
Grok Bot opens **Cursor cloud agents** against the knowledge tree. That session does not see the Claude/Grok plugin cache.

## What this ships

- `.cursor-plugin/plugin.json` — Cursor Plugins manifest (skills + rules + commands when present)
- `.cursor/rules/second-brain.mdc` — always-on write protocol
- `docs/CURSOR.md` — local install + cloud-agent hole
- `docs/GROK_BOT.md` — Cursor section
- `hosts/cursor/SKILL.md`
- Host labels bumped in lockstep

Same `skills/`. Same scripts. No per-pack MCP.

Local Cursor: `/plugin marketplace add SpillwaveSolutions/second-brain-marketplace` then install this plugin.

Cloud Cursor on the brain: follow `AGENTS.md` + this pack's write protocol. Plugin install is optional. Raw Markdown writes are not.