### PR TITLE
docs(user-guide): re-sync the two pages v0.24.3 made stale (01M0B004MDMSVF1VT3F4PCCPKV)

### DIFF
--- a/docs/.index/publish-manifest.json
+++ b/docs/.index/publish-manifest.json
@@ -4144,9 +4144,9 @@
    "frozen": false,
    "page_name": "CLI-Reference",
    "render": "doc+banner",
-   "render_hash": "5aa3ee526999",
+   "render_hash": "c1d3f8d56dd2",
    "source": "docs/user_guide/cli-reference.md",
-   "source_hash": "3579ceb4deea",
+   "source_hash": "d4383424fc6c",
    "title": "WikiTicket SDD \u2014 CLI Reference",
    "truth_state": "current",
    "wiki_key": "cli-reference"
@@ -4816,9 +4816,9 @@
    "frozen": false,
    "page_name": "Plugin-Guide",
    "render": "doc+banner",
-   "render_hash": "97a2085eb427",
+   "render_hash": "c07b4c1c733a",
    "source": "docs/user_guide/plugin-guide.md",
-   "source_hash": "d2f631467bfc",
+   "source_hash": "75a415d1d174",
    "title": "WikiTicket SDD \u2014 Plugin Guide",
    "truth_state": "current",
    "wiki_key": "plugin-guide"

--- a/docs/user_guide/cli-reference.md
+++ b/docs/user_guide/cli-reference.md
@@ -392,9 +392,16 @@ bin/worklog sync --dry-run
 | Flag | Meaning |
 |---|---|
 | `--dry-run` | Report what would happen; write nothing |
-| `--keys k1,k2` | Restrict the run to specific external keys |
+| `--keys k1,k2` | **Adds** these external keys to the run's scope; never narrows it |
 | `--push-only` / `--pull-only` | One direction only (mutually exclusive) |
 | `--retry-base-delay <s>` | Base backoff for transient adapter failures |
+
+*(0.24.3)* `--keys` is additive, not a filter: the scope is *open* ∪
+*hash-dirty* ∪ `--keys`, so naming one key does not stop the rest of a dirty
+log from syncing. There is deliberately no flag that narrows a run — a sync
+that skipped dirty items would leave the tracker further from the log, which
+is the drift `sync` exists to close. Use `--dry-run` to see what a run will
+touch before it writes.
 
 Every run ends with the drift report — one counts line, then the fields it
 overwrote on live tickets, then a `drift:` list of anything else a human

--- a/docs/user_guide/plugin-guide.md
+++ b/docs/user_guide/plugin-guide.md
@@ -147,8 +147,8 @@ ships hooks for the invariants:
 |---|---|---|
 | `ExitPlanMode` (PostToolUse) | a plan is approved | Invokes plan-capture non-optionally — every plan becomes tracked items |
 | `UserPromptSubmit` | each prompt | One-line reminder: requests that produce work get worklog items first; keep statuses moving. Also heartbeats this session into `.work/.sessions` and appends the concurrent-session warning when another session is live in the same checkout |
-| `Stop` | Claude finishes responding | If the working tree changed but `.work/todo.jsonl` didn't, block once: record the work items or explain. With `classifier.enabled: true` in `.work/config.yml` (**off by default**) it also triggers the classify skill — propose-only suggestions to `.work/suggestions.jsonl`, promoted into real items only via `worklog promote` |
-| `SessionStart` | session opens | Doctor-lite: checks the CLAUDE.md policy block, hook wiring, and version skew; points at `/worklog:init` or `/worklog:doctor` if something's off |
+| `Stop` | Claude finishes responding | If the working tree changed but `.work/todo.jsonl` hasn't moved since the commit this session started at, block once: record the work items or explain. *(0.24.3)* That start commit is stamped by `SessionStart` and never moves, so recording items and then committing them — the rhythm the policy asks for — still reads as recorded; no marker falls back to `HEAD`. With `classifier.enabled: true` in `.work/config.yml` (**off by default**) it also triggers the classify skill — propose-only suggestions to `.work/suggestions.jsonl`, promoted into real items only via `worklog promote` |
+| `SessionStart` | session opens | Doctor-lite: checks the CLAUDE.md policy block, hook wiring, and version skew; points at `/worklog:init` or `/worklog:doctor` if something's off. Also stamps the commit this session begins at into `.work/.sessions`, which is the fixed point the `Stop` check diffs against |
 | `SessionEnd` | session closes | Drops this session from `.work/.sessions`, so a finished session stops warning the next one that opens the directory |
 
 All hooks are silent outside worklog repos (no `bin/worklog`, no output), so


### PR DESCRIPTION
## What this is

Post-release documentation sync for **v0.24.3**, user-guide half. The scope is
exactly `git diff v0.24.2..v0.24.3` — two user-facing pages carried claims the
release falsified, and this PR corrects those two claims and nothing else.

## Why it matters

`docs/user_guide/` is what someone reads *instead of* the source. A page that
describes the old behavior of a hook or a flag is worse than a missing page:
the reader has no signal that it is wrong. Both corrections here are places
where the release fixed the code and left the prose describing the bug.

## The two changes

**1. `--keys` is additive, not a filter** (`cli-reference.md`)

The sync flag table read `Restrict the run to specific external keys`. That is
precisely the misreading v0.24.3 set out to kill — it is what caused a bug to
be filed against correct behavior. Sync scope is *open* ∪ *hash-dirty* ∪
`--keys`; the flag widens a run and can never narrow one. The table entry now
says that, with a short note underneath on why no narrowing flag exists (a sync
that skipped dirty items would leave the tracker further from the log, which is
the drift `sync` exists to close).

The wording matches what already landed in `docs/worklog-spec.md` in the
release commit rather than inventing a second phrasing for the same rule.

**2. The Stop hook diffs against session start, not HEAD** (`plugin-guide.md`)

The hook table said the Stop check fires when the tree changed "but
`.work/todo.jsonl` didn't" — meaning didn't change *versus HEAD*. That was the
v0.24.3 bug in one clause: a session that recorded its items and then committed
them destroyed its own proof and got blocked for following the policy exactly.

The row now says the check diffs against the commit the session began at, notes
that committing your own log mid-session still reads as recorded, and mentions
the `HEAD` fallback. The `SessionStart` row is extended to name the stamp it
writes into `.work/.sessions`, so the two rows describe one mechanism instead of
leaving the Stop row pointing at something undocumented.

## What was deliberately left alone

- **The compaction self-check.** Real, but internal to `.github/workflows/compact.yml`.
  No user-facing page documents that workflow's steps — `cli-reference.md` names the
  file and stops there, and that sentence is still true.
- **The README version marker.** Already at v0.24.3 from the release commit, and
  pinned by `tests/test_plugin.py`.
- **The README generally, and `user-guide.md`.** Neither describes the Stop hook's
  diff base or `--keys` semantics. Nothing in them went stale.
- **`docs/designs/`.** Owned by the parallel design-doc sync.

An unnecessary doc rewrite costs review time and breaks citation provenance, so
the diff stops where staleness stops.

## Housekeeping

`docs/.index/publish-manifest.json` moves because the two edited pages' body
hashes change — regenerated via `roadmap-render` → `ia-inventory` → `ia-manifest`
in that order. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQqJmYQ3rnAGZHPGGYHsR8