### PR TITLE
fix: preserve compact conflicts, write envelope, sync cursor (#390)

### DIFF
--- a/.github/workflows/worklog.yml
+++ b/.github/workflows/worklog.yml
@@ -57,6 +57,9 @@ jobs:
         run: |
           python3 tests/test_fold.py
           python3 tests/test_ulid.py
+          python3 tests/test_compact.py
+          python3 tests/test_github_adapter.py
+          python3 tests/test_merge_green.py
           python3 tests/test_render_roadmap.py
           python3 tests/test_plan_capture.py
           python3 tests/test_ia.py
@@ -77,6 +80,7 @@ jobs:
           python3 tests/test_bug_381.py
           python3 tests/test_bug_382.py
           python3 tests/test_bug_383.py
+          python3 plugin/tests/test_three_host_hooks.py
 
   coverage:
     if: github.event_name != 'workflow_run'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 .coverage.*
 tmp/
 .work/.sessions
+.work/.lock
 
 # Isolation session bookkeeping
 .brain-sessions/

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,13 +1,13 @@
 {
   "name": "worklog-marketplace",
   "description": "Grok marketplace pin for WikiTicket SDD. Grok Build also loads Claude plugins zero-config.",
-  "version": "0.24.8",
+  "version": "0.24.9",
   "plugins": [
     {
       "name": "worklog",
       "source": "./plugin",
       "description": "Git-native plans, tickets, roadmaps, wiki publishing.",
-      "version": "0.24.8",
+      "version": "0.24.9",
       "compatibility": {
         "claude_plugin": true,
         "zero_config": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Compaction preserves open sync conflicts.** Snapshots are built from public fields, which stripped `_conflicts`; the nightly compact then verified the stripped form and silently dropped every open conflict. Compact now re-emits `conflict` events above each snapshot and verifies the private map too.
+- **Write envelope, flock, monotonic ULIDs.** `worklog` byte-caps the whole encoded event (PIPE_BUF 4096), checks `os.write`, and holds `.work/.lock` across append so a concurrent compact cannot replace the inode mid-write. `ulid.new()` increments entropy inside the same millisecond so create-then-update cannot fold out of order.
+- **Merge bootstrap self-heals.** SessionStart doctor writes `merge.ours.driver` and `core.hooksPath` (absolute in linked worktrees). `doctor --fix-wiring` does the same on demand; `init.sh` is worktree-aware.
+- **Sync correctness.** Pull holds the since-cursor when ingest/conflict writes fail; `--keys` is forwarded to the adapter as a point query; `WORKLOG_TICKET_PROJECT` is exported from `ticketing.project` when unset. GitHub `to_line` emits a readable body (so remote body edits conflict instead of being clobbered) and warns at the 1000-issue listing cap.
+- **Faster merge.** `merge-when-green` arms `gh pr merge --auto --merge` up front and polls at 60s as fallback. Never squash (ADR-0008).
+- **Cursor port.** `cursor-hooks.json` paths resolve against the plugin root (`./hooks/scripts/...`). Host-parity test is a real unittest in CI. `.grok-plugin/marketplace.json` locksteps to 0.24.9.
+
 ## 0.24.9 — 2026-08-27
 
 - **Push-only sync absorbs tracker-only tickets and closed-on-remote drift (#385).** `worklog sync` (including `--push-only`) lists remote tickets with no worklog marker as a first-class drift class and prints the `worklog adopt --system … --key …` repair. A linked ticket that is closed remotely while the log item is still open is closed locally (`worklog close`) instead of pushing the open state back over it. `worklog adopt` creates the log item, links it, and stamps the ULID marker so the next push updates. Docs: never `gh issue create` / `gh issue edit` on a worklog-managed tracker — child worktrees add via `worklog` or they do not file tracker issues.

--- a/adapters/github/adapter
+++ b/adapters/github/adapter
@@ -214,6 +214,9 @@ def to_line(issue):
         "id": ids[0] if ids else None,
         "title": issue.get("title"),
     }
+    readable = readable_body(body)
+    if readable:
+        line["body"] = readable
     if issue.get("url"):
         line["external"]["url"] = issue["url"]
     if (issue.get("state") or "").upper() == "CLOSED":
@@ -314,7 +317,10 @@ def cmd_pull(argv):
               "--limit", "1000",
               "--json", ISSUE_JSON,
               "-S", f"worklog: in:body updated:>{since}"])
-    for issue in json.loads(out):
+    issues = json.loads(out)
+    if len(issues) >= 1000:
+        log("listing capped at 1000 issues; some tickets may be missing from pull")
+    for issue in issues:
         print(json.dumps(to_line(issue)))
         seen.add(issue["number"])
     # Open issues with no worklog marker are tracker-only orphans (#385),
@@ -332,11 +338,7 @@ def cmd_pull(argv):
 
 def cmd_get(key):
     issue = fetch_issue(target_repo(), key)
-    line = to_line(issue)
-    body = readable_body(issue.get("body") or "")
-    if body:
-        line["body"] = body
-    print(json.dumps(line))
+    print(json.dumps(to_line(issue)))
 
 
 def cmd_close(key, resolution):

--- a/bin/compact.py
+++ b/bin/compact.py
@@ -22,6 +22,7 @@ mode in this system.
 """
 import json
 import os
+import fcntl
 import subprocess
 import sys
 import time
@@ -38,8 +39,47 @@ def _now():
 
 def _public(item):
     """Item state minus private _fields -- what a snapshot carries and what
-    verification compares."""
+    verification compares for ordinary fields. `_conflicts` is private but
+    must still survive compaction: it is recorded as `conflict` events
+    above the snapshot, not stuffed into `set`."""
     return {k: v for k, v in item.items() if not k.startswith("_")}
+
+
+def _conflicts_map(result):
+    """Open conflicts per item. Missing and empty are the same (no conflicts)."""
+    out = {}
+    for iid, item in result.items.items():
+        cs = item.get("_conflicts") or []
+        if cs:
+            out[iid] = cs
+    return out
+
+
+def _conflict_event(item, conflict):
+    """Re-emit one open conflict above a snapshot so the fold restores it."""
+    ev = {"ev": ulid.new(), "ts": _now(), "actor": "compactor",
+          "item": item["id"], "op": "conflict", "set": conflict}
+    sha = ulid.git_commit()
+    if sha:
+        ev["git"] = sha
+    return ev
+
+
+def _item_events(item, through=None):
+    """Snapshot plus any open conflicts, in fold order (snapshot, then conflicts)."""
+    events = [_snapshot(item, through)]
+    for c in item.get("_conflicts") or []:
+        events.append(_conflict_event(item, c))
+    return events
+
+
+def _lock_logs(todo_path):
+    """Exclusive lock covering compact vs append. Spec §8.3."""
+    lock_path = os.path.join(os.path.dirname(os.path.abspath(todo_path)) or ".",
+                             ".lock")
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
 
 
 def _snapshot(item, through=None):
@@ -128,6 +168,14 @@ def _verify(before, tmp_todo, tmp_done):
                       file=sys.stderr)
         print("compact: aborted; logs untouched", file=sys.stderr)
         raise SystemExit(1)
+    old_c, new_c = _conflicts_map(before), _conflicts_map(after)
+    if old_c != new_c:
+        print("compact: VERIFY FAILED: open conflicts were not preserved\n"
+              f"  before: {json.dumps(old_c, sort_keys=True)}\n"
+              f"  after:  {json.dumps(new_c, sort_keys=True)}",
+              file=sys.stderr)
+        print("compact: aborted; logs untouched", file=sys.stderr)
+        raise SystemExit(1)
     for path in (tmp_todo, tmp_done):
         with open(path, "rb") as fh:
             data = fh.read()
@@ -148,16 +196,24 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
               "(compaction must be its own commit, spec 7)", file=sys.stderr)
         raise SystemExit(1)
 
+    lock_fd = _lock_logs(todo_path)
+    try:
+        return _compact_locked(todo_path, done_path)
+    finally:
+        os.close(lock_fd)
+
+
+def _compact_locked(todo_path, done_path):
     watermark = max_ev([todo_path, done_path])         # step 2: raw max ev
     if watermark is None:
         return None
 
+    before = fold([todo_path, done_path])              # step 1: full history
     raw_todo = _raw_lines(todo_path)
-    if all(e is not None and e.get("op") in ("snapshot", "compact")
+    idle_ops = ("snapshot", "compact", "conflict")
+    if all(e is not None and e.get("op") in idle_ops
            for _line, e in raw_todo):
         return watermark  # nothing new since the last run; don't churn files
-
-    before = fold([todo_path, done_path])              # step 1: full history
 
     # Highest ev this run actually folded, PER ITEM (#284). Taken from the raw
     # input lines, not from the fold, because it must describe what was read
@@ -179,9 +235,11 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
          else open_items).append(item)
     open_ids = {i["id"] for i in open_items}
 
-    # step 4: new todo = open snapshots + watermark
-    todo_text = _dump([_snapshot(i, per_item.get(i["id"])) for i in open_items]
-                      + [_compact_line(watermark)])
+    # step 4: new todo = open snapshots + open conflicts + watermark
+    todo_events = []
+    for i in open_items:
+        todo_events.extend(_item_events(i, per_item.get(i["id"])))
+    todo_text = _dump(todo_events + [_compact_line(watermark)])
 
     # steps 5+6: new done = old lines minus open items, plus snapshots for
     # newly-closed items not already there with identical state, plus watermark.
@@ -196,8 +254,10 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
         if parsed.get("item") in open_ids:
             continue  # stale snapshot/event for a reopened item (step 6)
         kept.append(line + "\n")
-    fresh = [_snapshot(i, per_item.get(i["id"])) for i in closed_items
-             if done_state.get(i["id"]) != _public(i)]
+    fresh = []
+    for i in closed_items:
+        if done_state.get(i["id"]) != _public(i) or i.get("_conflicts"):
+            fresh.extend(_item_events(i, per_item.get(i["id"])))
     done_text = "".join(kept) + _dump(fresh + [_compact_line(watermark)])
 
     tmp_todo, tmp_done = todo_path + ".compact", done_path + ".compact"
@@ -329,10 +389,8 @@ def _reissue(event, ms):
 
     The original `ev` is below the watermark, so the fold would drop it -- the
     intent has to be re-emitted under an id that sorts above. Timestamps are
-    handed in explicitly and strictly increasing: ulid.new() has no
-    intra-millisecond counter, so two reissues generated in the same
-    millisecond would sort by random bytes and replay the branch's events out
-    of order.
+    handed in explicitly and strictly increasing so a batch of reissues keeps
+    the branch's order even when they land in one millisecond.
     """
     fresh = {"ev": ulid.new(ms), "ts": _now(), "actor": event.get("actor", "rescue"),
              "item": event["item"], "op": event["op"], "rescued_from": event["ev"]}

--- a/bin/sync_dispatch.py
+++ b/bin/sync_dispatch.py
@@ -162,6 +162,44 @@ def resolve_adapter():
         return None
 
 
+def forward_ticket_env(config_path=".work/config.yml"):
+    """Copy ticketing.project / ticketing.system into the adapter env.
+
+    The contract (typed-adapter-contract §3) says connection details arrive
+    via WORKLOG_TICKET_PROJECT; nothing was producing that variable. GitHub
+    papers over the gap with `gh repo view`; a Jira adapter cannot.
+    """
+    if (os.environ.get("WORKLOG_TICKET_PROJECT")
+            and os.environ.get("WORKLOG_TICKET_SYSTEM")):
+        return
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return
+    project = system = None
+    inside = False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line[:1] not in " \t":
+            inside = line.strip().startswith("ticketing:")
+            continue
+        if not inside or ":" not in line:
+            continue
+        key, val = line.split(":", 1)
+        key, val = key.strip(), val.strip().strip("\"'")
+        if key == "project" and val:
+            project = val
+        elif key == "system" and val:
+            system = val
+    if project and not os.environ.get("WORKLOG_TICKET_PROJECT"):
+        os.environ["WORKLOG_TICKET_PROJECT"] = project
+    if system and system != "none" and not os.environ.get("WORKLOG_TICKET_SYSTEM"):
+        os.environ["WORKLOG_TICKET_SYSTEM"] = system
+
+
 class Dispatcher:
     COUNT_KEYS = ("created", "updated", "closed", "skipped", "pulled",
                   "conflicts", "deferred")
@@ -260,6 +298,7 @@ class Dispatcher:
     # --- process seams ---
 
     def run_adapter(self, *args, stdin=None):
+        forward_ticket_env()
         p = subprocess.run([self.adapter, *args], input=stdin,
                            capture_output=True, text=True)
         if p.stderr:
@@ -743,6 +782,26 @@ class Dispatcher:
 
     # --- pull side ---
 
+    def _adapter_keys(self, keys, by_id):
+        """Resolve --keys (item ULIDs or ticket numbers) to adapter keys."""
+        out = []
+        for k in keys:
+            item = by_id.get(k)
+            if item is not None:
+                remembered = self.remembered_key(k, item.get("external") or {})
+                if remembered:
+                    out.append(str(remembered))
+            else:
+                out.append(k)
+        # Preserve order, drop empties/dupes.
+        seen = set()
+        unique = []
+        for k in out:
+            if k and k not in seen:
+                seen.add(k)
+                unique.append(k)
+        return unique
+
     def pull(self, caps, items, keys):
         if "pull" not in caps["supports"]:
             self.note("adapter does not support pull; local log may lag remote")
@@ -753,7 +812,13 @@ class Dispatcher:
         # local event instead of calling with neither (worklog#141).
         cursor = (self.state.get("cursors", {}).get(system)
                  or earliest_event_ts() or EPOCH)
-        args = ["pull", "--since", cursor]
+        by_id = {i["id"]: i for i in items}
+        adapter_keys = self._adapter_keys(keys, by_id) if keys else []
+        keyed = bool(adapter_keys)
+        if keyed:
+            args = ["pull", "--keys", ",".join(adapter_keys)]
+        else:
+            args = ["pull", "--since", cursor]
         p = self.run_adapter(*args)
         if p.returncode == 2:
             sys.exit("worklog sync: adapter auth failure on pull — "
@@ -762,8 +827,8 @@ class Dispatcher:
             self.note("pull failed (exit %d); cursor not advanced" % p.returncode)
             return
         self.adapter_ok = True   # a clean pull proves the project is reachable
-        by_id = {i["id"]: i for i in items}
         max_rev = cursor
+        ingest_failed = False
         for raw in p.stdout.splitlines():
             if not raw.strip():
                 continue
@@ -812,12 +877,20 @@ class Dispatcher:
             if both:
                 # Both sides moved since last push (spec §10.6): record,
                 # never overwrite under the default report policy.
+                wrote = True
                 for f in changed:
-                    self.worklog("conflict", iid, "--field", f,
-                                 "--local", str(local.get(f)),
-                                 "--remote", str(line[f]),
-                                 "--remote-rev", rev or "", fatal=False)
-                    self.counts["conflicts"] += 1
+                    if self.worklog("conflict", iid, "--field", f,
+                                    "--local", str(local.get(f)),
+                                    "--remote", str(line[f]),
+                                    "--remote-rev", rev or "",
+                                    fatal=False) is None:
+                        wrote = False
+                        ingest_failed = True
+                    else:
+                        self.counts["conflicts"] += 1
+                if not wrote:
+                    self.note("pull: conflict record failed on %s; "
+                              "cursor held" % iid[:8])
             else:
                 ing = ["ingest", iid, "--system", system,
                        "--key", str(ext.get("key")), "--rev", rev or "",
@@ -826,9 +899,20 @@ class Dispatcher:
                     ing += ["--set", "%s=%s" % (f, line[f])]
                 if self.worklog(*ing, fatal=False) is not None:
                     self.counts["pulled"] += 1
-        if max_rev and not self.dry_run:
+                else:
+                    ingest_failed = True
+                    self.note("pull: ingest failed on %s; cursor held"
+                              % iid[:8])
+        # A --keys pull is a point query: do not move the since cursor.
+        # A failed ingest must not advance it either, or that remote edit
+        # is skipped until the ticket changes again.
+        if keyed or self.dry_run:
+            return
+        if ingest_failed:
+            self.note("pull: cursor not advanced past failed ingest")
+            return
+        if max_rev:
             self.state.setdefault("cursors", {})[system] = max_rev
-
     def commit_gone(self):
         """Flush the run's buffered gone marks into state.
 

--- a/bin/ulid.py
+++ b/bin/ulid.py
@@ -107,6 +107,10 @@ def git_commit_full() -> str:
     return _rev_parse(short=False)
 
 
+_last_ms = -1
+_last_entropy = None
+
+
 def new(timestamp_ms: int = None) -> str:
     """A fresh ULID for a locally-originated event.
 
@@ -118,9 +122,25 @@ def new(timestamp_ms: int = None) -> str:
     event's `git` field instead -- which also traces better, since an item's
     id is minted once and could only ever name the branch the ITEM was
     created on, while a field on every event names the origin of each one.
+
+    Same-millisecond calls are monotonic: the 80-bit entropy increments so
+    create-then-update in one tick cannot fold out of order (merge-rescue
+    already worked around this; the mint path does it too).
     """
+    global _last_ms, _last_entropy
     ms = int(time.time() * 1000) if timestamp_ms is None else timestamp_ms
-    return encode(ms, os.urandom(10))
+    if ms == _last_ms and _last_entropy is not None:
+        n = int.from_bytes(_last_entropy, "big") + 1
+        if n >= (1 << 80):
+            ms += 1
+            entropy = os.urandom(10)
+        else:
+            entropy = n.to_bytes(10, "big")
+    else:
+        entropy = os.urandom(10)
+    _last_ms = ms
+    _last_entropy = entropy
+    return encode(ms, entropy)
 
 
 def deterministic(system: str, key: str, rev: str, rev_timestamp_ms: int) -> str:

--- a/bin/worklog
+++ b/bin/worklog
@@ -22,7 +22,7 @@ triages it (never silently `feature`).
 
 Nothing else in the repo may write to .work/*.jsonl (invariant 15.4).
 """
-import argparse, glob, json, os, re, sys, time
+import argparse, glob, json, os, re, sys, time, fcntl
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ulid
 import item_fields
@@ -31,7 +31,9 @@ from fold import (fold, FoldResult, read_lines, dedupe_and_sort, external_owners
 
 LOG = ".work/todo.jsonl"
 PATHS = (".work/todo.jsonl", ".work/done.jsonl")
-MAX_BODY = 2048  # derived from PIPE_BUF (section 8.3). Not a setting.
+MAX_BODY = 2048  # body UTF-8 bytes; derived from PIPE_BUF (section 8.3). Not a setting.
+MAX_LINE = 4096  # POSIX PIPE_BUF; the whole encoded event must fit for atomicity.
+LOCK = ".work/.lock"
 VERSION = "0.24.9"  # kept in step with plugin/.claude-plugin/plugin.json by tests/test_plugin.py
 
 
@@ -64,24 +66,40 @@ def append(event):
     Also self-heals a missing trailing newline on the existing file (a hand
     edit the hook hasn't caught yet): appending without the repair would fuse
     two events into one unparseable line and lose both (section 8.2).
+
+    Holds `.work/.lock` so a concurrent compact cannot os.replace the inode
+    this write is targeting (spec §8.3).
     """
-    if len(event.get("set", {}).get("body", "")) > MAX_BODY:
+    body = event.get("set", {}).get("body", "")
+    if isinstance(body, str) and len(body.encode("utf-8")) > MAX_BODY:
         sys.exit(f"worklog: body exceeds {MAX_BODY}B; put prose in the plan doc")
     _warn_concurrent_sessions()
     line = json.dumps(event, separators=(",", ":"), sort_keys=True) + "\n"
-    fd = os.open(LOG, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    raw = line.encode("utf-8")
+    if len(raw) > MAX_LINE:
+        sys.exit(f"worklog: event exceeds {MAX_LINE}B atomicity envelope "
+                 "(PIPE_BUF); shorten title or move prose to the plan doc")
+    os.makedirs(os.path.dirname(LOG) or ".", exist_ok=True)
+    lock_fd = os.open(LOCK, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        if os.fstat(fd).st_size:
-            rfd = os.open(LOG, os.O_RDONLY)
-            try:
-                os.lseek(rfd, -1, os.SEEK_END)
-                if os.read(rfd, 1) != b"\n":
-                    line = "\n" + line
-            finally:
-                os.close(rfd)
-        os.write(fd, line.encode())   # atomic under PIPE_BUF
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        fd = os.open(LOG, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            if os.fstat(fd).st_size:
+                rfd = os.open(LOG, os.O_RDONLY)
+                try:
+                    os.lseek(rfd, -1, os.SEEK_END)
+                    if os.read(rfd, 1) != b"\n":
+                        raw = b"\n" + raw
+                finally:
+                    os.close(rfd)
+            n = os.write(fd, raw)
+            if n != len(raw):
+                sys.exit("worklog: short write; event not recorded")
+        finally:
+            os.close(fd)
     finally:
-        os.close(fd)
+        os.close(lock_fd)
     return event
 
 

--- a/hooks/session-doctor.sh
+++ b/hooks/session-doctor.sh
@@ -22,6 +22,21 @@ except Exception:
     pass
 ' 2>/dev/null || true
 
+# Auto-repair clone wiring. Two idempotent git config lines. The Catch-22
+# is that pre-commit would self-heal merge.ours.driver, but pre-commit never
+# runs until core.hooksPath is set — so SessionStart has to do it.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git config merge.ours.driver true 2>/dev/null || true
+  git_dir=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P || true)
+  common=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)
+  hooks_abs="$(pwd -P)/hooks"
+  if [ -n "$git_dir" ] && [ -n "$common" ] && [ "$git_dir" != "$common" ] && [ -d "$hooks_abs" ]; then
+    git config core.hooksPath "$hooks_abs" 2>/dev/null || true
+  elif [ -d hooks ]; then
+    git config core.hooksPath hooks 2>/dev/null || true
+  fi
+fi
+
 # doctor-lite: read-only, never blocks, reports only failures. Healthy → no output.
 fails=()
 

--- a/plugin/hooks/cursor-hooks.json
+++ b/plugin/hooks/cursor-hooks.json
@@ -1,25 +1,25 @@
 {
   "version": 1,
-  "description": "Cursor-native hook port of Claude Code hooks.json. Shared scripts; event names mapped.",
+  "description": "Cursor-native hook port of Claude Code hooks.json. Shared scripts; event names mapped. Paths resolve against the plugin root (marketplace source: ./plugin).",
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "command": "./plugin/hooks/scripts/prompt-reminder.sh"
+        "command": "./hooks/scripts/prompt-reminder.sh"
       }
     ],
     "stop": [
       {
-        "command": "./plugin/hooks/scripts/stop-worklog-check.sh"
+        "command": "./hooks/scripts/stop-worklog-check.sh"
       }
     ],
     "sessionStart": [
       {
-        "command": "./plugin/hooks/scripts/session-doctor.sh"
+        "command": "./hooks/scripts/session-doctor.sh"
       }
     ],
     "sessionEnd": [
       {
-        "command": "./plugin/hooks/scripts/session-end.sh"
+        "command": "./hooks/scripts/session-end.sh"
       }
     ]
   }

--- a/plugin/hooks/scripts/session-doctor.sh
+++ b/plugin/hooks/scripts/session-doctor.sh
@@ -22,6 +22,21 @@ except Exception:
     pass
 ' 2>/dev/null || true
 
+# Auto-repair clone wiring. Two idempotent git config lines. The Catch-22
+# is that pre-commit would self-heal merge.ours.driver, but pre-commit never
+# runs until core.hooksPath is set — so SessionStart has to do it.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git config merge.ours.driver true 2>/dev/null || true
+  git_dir=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P || true)
+  common=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P || true)
+  hooks_abs="$(pwd -P)/hooks"
+  if [ -n "$git_dir" ] && [ -n "$common" ] && [ "$git_dir" != "$common" ] && [ -d "$hooks_abs" ]; then
+    git config core.hooksPath "$hooks_abs" 2>/dev/null || true
+  elif [ -d hooks ]; then
+    git config core.hooksPath hooks 2>/dev/null || true
+  fi
+fi
+
 # doctor-lite: read-only, never blocks, reports only failures. Healthy → no output.
 fails=()
 

--- a/plugin/scripts/compact.py
+++ b/plugin/scripts/compact.py
@@ -22,6 +22,7 @@ mode in this system.
 """
 import json
 import os
+import fcntl
 import subprocess
 import sys
 import time
@@ -38,8 +39,47 @@ def _now():
 
 def _public(item):
     """Item state minus private _fields -- what a snapshot carries and what
-    verification compares."""
+    verification compares for ordinary fields. `_conflicts` is private but
+    must still survive compaction: it is recorded as `conflict` events
+    above the snapshot, not stuffed into `set`."""
     return {k: v for k, v in item.items() if not k.startswith("_")}
+
+
+def _conflicts_map(result):
+    """Open conflicts per item. Missing and empty are the same (no conflicts)."""
+    out = {}
+    for iid, item in result.items.items():
+        cs = item.get("_conflicts") or []
+        if cs:
+            out[iid] = cs
+    return out
+
+
+def _conflict_event(item, conflict):
+    """Re-emit one open conflict above a snapshot so the fold restores it."""
+    ev = {"ev": ulid.new(), "ts": _now(), "actor": "compactor",
+          "item": item["id"], "op": "conflict", "set": conflict}
+    sha = ulid.git_commit()
+    if sha:
+        ev["git"] = sha
+    return ev
+
+
+def _item_events(item, through=None):
+    """Snapshot plus any open conflicts, in fold order (snapshot, then conflicts)."""
+    events = [_snapshot(item, through)]
+    for c in item.get("_conflicts") or []:
+        events.append(_conflict_event(item, c))
+    return events
+
+
+def _lock_logs(todo_path):
+    """Exclusive lock covering compact vs append. Spec §8.3."""
+    lock_path = os.path.join(os.path.dirname(os.path.abspath(todo_path)) or ".",
+                             ".lock")
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    return fd
 
 
 def _snapshot(item, through=None):
@@ -128,6 +168,14 @@ def _verify(before, tmp_todo, tmp_done):
                       file=sys.stderr)
         print("compact: aborted; logs untouched", file=sys.stderr)
         raise SystemExit(1)
+    old_c, new_c = _conflicts_map(before), _conflicts_map(after)
+    if old_c != new_c:
+        print("compact: VERIFY FAILED: open conflicts were not preserved\n"
+              f"  before: {json.dumps(old_c, sort_keys=True)}\n"
+              f"  after:  {json.dumps(new_c, sort_keys=True)}",
+              file=sys.stderr)
+        print("compact: aborted; logs untouched", file=sys.stderr)
+        raise SystemExit(1)
     for path in (tmp_todo, tmp_done):
         with open(path, "rb") as fh:
             data = fh.read()
@@ -148,16 +196,24 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
               "(compaction must be its own commit, spec 7)", file=sys.stderr)
         raise SystemExit(1)
 
+    lock_fd = _lock_logs(todo_path)
+    try:
+        return _compact_locked(todo_path, done_path)
+    finally:
+        os.close(lock_fd)
+
+
+def _compact_locked(todo_path, done_path):
     watermark = max_ev([todo_path, done_path])         # step 2: raw max ev
     if watermark is None:
         return None
 
+    before = fold([todo_path, done_path])              # step 1: full history
     raw_todo = _raw_lines(todo_path)
-    if all(e is not None and e.get("op") in ("snapshot", "compact")
+    idle_ops = ("snapshot", "compact", "conflict")
+    if all(e is not None and e.get("op") in idle_ops
            for _line, e in raw_todo):
         return watermark  # nothing new since the last run; don't churn files
-
-    before = fold([todo_path, done_path])              # step 1: full history
 
     # Highest ev this run actually folded, PER ITEM (#284). Taken from the raw
     # input lines, not from the fold, because it must describe what was read
@@ -179,9 +235,11 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
          else open_items).append(item)
     open_ids = {i["id"] for i in open_items}
 
-    # step 4: new todo = open snapshots + watermark
-    todo_text = _dump([_snapshot(i, per_item.get(i["id"])) for i in open_items]
-                      + [_compact_line(watermark)])
+    # step 4: new todo = open snapshots + open conflicts + watermark
+    todo_events = []
+    for i in open_items:
+        todo_events.extend(_item_events(i, per_item.get(i["id"])))
+    todo_text = _dump(todo_events + [_compact_line(watermark)])
 
     # steps 5+6: new done = old lines minus open items, plus snapshots for
     # newly-closed items not already there with identical state, plus watermark.
@@ -196,8 +254,10 @@ def compact(todo_path=".work/todo.jsonl", done_path=".work/done.jsonl"):
         if parsed.get("item") in open_ids:
             continue  # stale snapshot/event for a reopened item (step 6)
         kept.append(line + "\n")
-    fresh = [_snapshot(i, per_item.get(i["id"])) for i in closed_items
-             if done_state.get(i["id"]) != _public(i)]
+    fresh = []
+    for i in closed_items:
+        if done_state.get(i["id"]) != _public(i) or i.get("_conflicts"):
+            fresh.extend(_item_events(i, per_item.get(i["id"])))
     done_text = "".join(kept) + _dump(fresh + [_compact_line(watermark)])
 
     tmp_todo, tmp_done = todo_path + ".compact", done_path + ".compact"
@@ -329,10 +389,8 @@ def _reissue(event, ms):
 
     The original `ev` is below the watermark, so the fold would drop it -- the
     intent has to be re-emitted under an id that sorts above. Timestamps are
-    handed in explicitly and strictly increasing: ulid.new() has no
-    intra-millisecond counter, so two reissues generated in the same
-    millisecond would sort by random bytes and replay the branch's events out
-    of order.
+    handed in explicitly and strictly increasing so a batch of reissues keeps
+    the branch's order even when they land in one millisecond.
     """
     fresh = {"ev": ulid.new(ms), "ts": _now(), "actor": event.get("actor", "rescue"),
              "item": event["item"], "op": event["op"], "rescued_from": event["ev"]}

--- a/plugin/scripts/doctor.sh
+++ b/plugin/scripts/doctor.sh
@@ -1,14 +1,32 @@
 #!/usr/bin/env bash
 # worklog doctor: read-only health report. Exit 0 healthy, 1 if any check failed.
+# --fix-wiring: also write the two per-clone git config lines (hooksPath,
+# merge.ours.driver) so a fresh clone is not a silent hook-floor outage.
 set -uo pipefail
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+FIX_WIRING=0
+for arg in "$@"; do
+  [ "$arg" = "--fix-wiring" ] && FIX_WIRING=1
+done
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "FAIL not inside a git work tree"
   exit 1
 fi
 cd "$(git rev-parse --show-toplevel)"
+
+if [ "$FIX_WIRING" -eq 1 ]; then
+  git config merge.ours.driver true
+  git_dir=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+  common=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+  if [ "$git_dir" != "$common" ]; then
+    git config core.hooksPath "$(pwd -P)/hooks"
+  else
+    git config core.hooksPath hooks
+  fi
+  echo "ok    wiring repaired (core.hooksPath, merge.ours.driver)"
+fi
 
 fail=0
 ok()  { echo "ok    $*"; }

--- a/plugin/scripts/init.sh
+++ b/plugin/scripts/init.sh
@@ -103,7 +103,14 @@ if [ -f "$PLUGIN_ROOT/hooks/scripts/session-end.sh" ]; then
   chmod +x "hooks/session-end.sh"
   wrote+=("hooks/session-end.sh")
 fi
-git config core.hooksPath hooks
+git_dir=$(cd "$(git rev-parse --git-dir)" && pwd -P)
+common=$(cd "$(git rev-parse --git-common-dir)" && pwd -P)
+if [ "$git_dir" != "$common" ]; then
+  # Linked worktree: relative hooksPath resolves against the wrong CWD.
+  git config core.hooksPath "$(pwd -P)/hooks"
+else
+  git config core.hooksPath hooks
+fi
 # Built-in `union` needs no config. `ours` is a named driver, not a built-in:
 # `driver = true` is a no-op that succeeds and leaves the file as ours, which
 # is what pre-merge-commit then regenerates (#381).

--- a/plugin/scripts/merge-when-green.sh
+++ b/plugin/scripts/merge-when-green.sh
@@ -2,6 +2,10 @@
 # Merge a PR only when every check is green. Polls until then. Never bypasses
 # a gate: a failing check is a stop, not an obstacle. GitHub via gh; other
 # platforms use their CLI equivalent per the merge-green skill.
+#
+# Auto-merge is armed up front (`gh pr merge --auto --merge`) so GitHub
+# merges server-side the moment checks go green. The poll loop is the
+# fallback reporter, not the merge mechanism. Never squash (ADR-0008).
 set -euo pipefail
 
 # Optional first arg forces auto-merge on/off for this run only.
@@ -12,8 +16,8 @@ case "${1:-}" in
 esac
 
 PR="${1:?usage: merge-when-green.sh [--advisory|--auto] <pr-number> [interval-seconds] [max-attempts]}"
-INTERVAL="${2:-300}"   # 5 minutes
-MAX="${3:-24}"         # 24 × 5 min = 2 h, then give up loudly
+INTERVAL="${2:-60}"    # 1 minute; --auto makes the long poll a fallback
+MAX="${3:-120}"        # 120 × 60s = 2 h, then give up loudly
 
 # Resolve auto-merge: --advisory/--auto > WORKLOG_AUTO_MERGE=0|1 > config > true.
 # ponytail: naive block scan, same style as _config_system in bin/worklog
@@ -32,9 +36,27 @@ command -v gh >/dev/null 2>&1 || {
   exit 2
 }
 
+state=$(gh pr view "$PR" --json state -q .state)
+if [ "$state" != "OPEN" ]; then
+  echo "merge-when-green: PR #$PR is $state — nothing to merge" >&2
+  exit 3
+fi
+
+if [ "$AUTO_MERGE" = true ]; then
+  # Arm GitHub auto-merge now so the platform merges when checks go green
+  # instead of waiting for our next poll. Non-fatal: we still merge
+  # ourselves once green if --auto is unsupported or already pending.
+  echo "merge-when-green: arming auto-merge on PR #$PR" >&2
+  gh pr merge "$PR" --auto --merge || true
+fi
+
 for ((i = 1; i <= MAX; i++)); do
   state=$(gh pr view "$PR" --json state -q .state)
   if [ "$state" != "OPEN" ]; then
+    if [ "$state" = "MERGED" ]; then
+      echo "merge-when-green: PR #$PR is MERGED"
+      exit 0
+    fi
     echo "merge-when-green: PR #$PR is $state — nothing to merge" >&2
     exit 3
   fi

--- a/plugin/scripts/sync_dispatch.py
+++ b/plugin/scripts/sync_dispatch.py
@@ -162,6 +162,44 @@ def resolve_adapter():
         return None
 
 
+def forward_ticket_env(config_path=".work/config.yml"):
+    """Copy ticketing.project / ticketing.system into the adapter env.
+
+    The contract (typed-adapter-contract §3) says connection details arrive
+    via WORKLOG_TICKET_PROJECT; nothing was producing that variable. GitHub
+    papers over the gap with `gh repo view`; a Jira adapter cannot.
+    """
+    if (os.environ.get("WORKLOG_TICKET_PROJECT")
+            and os.environ.get("WORKLOG_TICKET_SYSTEM")):
+        return
+    try:
+        with open(config_path, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError:
+        return
+    project = system = None
+    inside = False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line[:1] not in " \t":
+            inside = line.strip().startswith("ticketing:")
+            continue
+        if not inside or ":" not in line:
+            continue
+        key, val = line.split(":", 1)
+        key, val = key.strip(), val.strip().strip("\"'")
+        if key == "project" and val:
+            project = val
+        elif key == "system" and val:
+            system = val
+    if project and not os.environ.get("WORKLOG_TICKET_PROJECT"):
+        os.environ["WORKLOG_TICKET_PROJECT"] = project
+    if system and system != "none" and not os.environ.get("WORKLOG_TICKET_SYSTEM"):
+        os.environ["WORKLOG_TICKET_SYSTEM"] = system
+
+
 class Dispatcher:
     COUNT_KEYS = ("created", "updated", "closed", "skipped", "pulled",
                   "conflicts", "deferred")
@@ -260,6 +298,7 @@ class Dispatcher:
     # --- process seams ---
 
     def run_adapter(self, *args, stdin=None):
+        forward_ticket_env()
         p = subprocess.run([self.adapter, *args], input=stdin,
                            capture_output=True, text=True)
         if p.stderr:
@@ -743,6 +782,26 @@ class Dispatcher:
 
     # --- pull side ---
 
+    def _adapter_keys(self, keys, by_id):
+        """Resolve --keys (item ULIDs or ticket numbers) to adapter keys."""
+        out = []
+        for k in keys:
+            item = by_id.get(k)
+            if item is not None:
+                remembered = self.remembered_key(k, item.get("external") or {})
+                if remembered:
+                    out.append(str(remembered))
+            else:
+                out.append(k)
+        # Preserve order, drop empties/dupes.
+        seen = set()
+        unique = []
+        for k in out:
+            if k and k not in seen:
+                seen.add(k)
+                unique.append(k)
+        return unique
+
     def pull(self, caps, items, keys):
         if "pull" not in caps["supports"]:
             self.note("adapter does not support pull; local log may lag remote")
@@ -753,7 +812,13 @@ class Dispatcher:
         # local event instead of calling with neither (worklog#141).
         cursor = (self.state.get("cursors", {}).get(system)
                  or earliest_event_ts() or EPOCH)
-        args = ["pull", "--since", cursor]
+        by_id = {i["id"]: i for i in items}
+        adapter_keys = self._adapter_keys(keys, by_id) if keys else []
+        keyed = bool(adapter_keys)
+        if keyed:
+            args = ["pull", "--keys", ",".join(adapter_keys)]
+        else:
+            args = ["pull", "--since", cursor]
         p = self.run_adapter(*args)
         if p.returncode == 2:
             sys.exit("worklog sync: adapter auth failure on pull — "
@@ -762,8 +827,8 @@ class Dispatcher:
             self.note("pull failed (exit %d); cursor not advanced" % p.returncode)
             return
         self.adapter_ok = True   # a clean pull proves the project is reachable
-        by_id = {i["id"]: i for i in items}
         max_rev = cursor
+        ingest_failed = False
         for raw in p.stdout.splitlines():
             if not raw.strip():
                 continue
@@ -812,12 +877,20 @@ class Dispatcher:
             if both:
                 # Both sides moved since last push (spec §10.6): record,
                 # never overwrite under the default report policy.
+                wrote = True
                 for f in changed:
-                    self.worklog("conflict", iid, "--field", f,
-                                 "--local", str(local.get(f)),
-                                 "--remote", str(line[f]),
-                                 "--remote-rev", rev or "", fatal=False)
-                    self.counts["conflicts"] += 1
+                    if self.worklog("conflict", iid, "--field", f,
+                                    "--local", str(local.get(f)),
+                                    "--remote", str(line[f]),
+                                    "--remote-rev", rev or "",
+                                    fatal=False) is None:
+                        wrote = False
+                        ingest_failed = True
+                    else:
+                        self.counts["conflicts"] += 1
+                if not wrote:
+                    self.note("pull: conflict record failed on %s; "
+                              "cursor held" % iid[:8])
             else:
                 ing = ["ingest", iid, "--system", system,
                        "--key", str(ext.get("key")), "--rev", rev or "",
@@ -826,9 +899,20 @@ class Dispatcher:
                     ing += ["--set", "%s=%s" % (f, line[f])]
                 if self.worklog(*ing, fatal=False) is not None:
                     self.counts["pulled"] += 1
-        if max_rev and not self.dry_run:
+                else:
+                    ingest_failed = True
+                    self.note("pull: ingest failed on %s; cursor held"
+                              % iid[:8])
+        # A --keys pull is a point query: do not move the since cursor.
+        # A failed ingest must not advance it either, or that remote edit
+        # is skipped until the ticket changes again.
+        if keyed or self.dry_run:
+            return
+        if ingest_failed:
+            self.note("pull: cursor not advanced past failed ingest")
+            return
+        if max_rev:
             self.state.setdefault("cursors", {})[system] = max_rev
-
     def commit_gone(self):
         """Flush the run's buffered gone marks into state.
 

--- a/plugin/scripts/ulid.py
+++ b/plugin/scripts/ulid.py
@@ -107,6 +107,10 @@ def git_commit_full() -> str:
     return _rev_parse(short=False)
 
 
+_last_ms = -1
+_last_entropy = None
+
+
 def new(timestamp_ms: int = None) -> str:
     """A fresh ULID for a locally-originated event.
 
@@ -118,9 +122,25 @@ def new(timestamp_ms: int = None) -> str:
     event's `git` field instead -- which also traces better, since an item's
     id is minted once and could only ever name the branch the ITEM was
     created on, while a field on every event names the origin of each one.
+
+    Same-millisecond calls are monotonic: the 80-bit entropy increments so
+    create-then-update in one tick cannot fold out of order (merge-rescue
+    already worked around this; the mint path does it too).
     """
+    global _last_ms, _last_entropy
     ms = int(time.time() * 1000) if timestamp_ms is None else timestamp_ms
-    return encode(ms, os.urandom(10))
+    if ms == _last_ms and _last_entropy is not None:
+        n = int.from_bytes(_last_entropy, "big") + 1
+        if n >= (1 << 80):
+            ms += 1
+            entropy = os.urandom(10)
+        else:
+            entropy = n.to_bytes(10, "big")
+    else:
+        entropy = os.urandom(10)
+    _last_ms = ms
+    _last_entropy = entropy
+    return encode(ms, entropy)
 
 
 def deterministic(system: str, key: str, rev: str, rev_timestamp_ms: int) -> str:

--- a/plugin/scripts/worklog
+++ b/plugin/scripts/worklog
@@ -22,7 +22,7 @@ triages it (never silently `feature`).
 
 Nothing else in the repo may write to .work/*.jsonl (invariant 15.4).
 """
-import argparse, glob, json, os, re, sys, time
+import argparse, glob, json, os, re, sys, time, fcntl
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ulid
 import item_fields
@@ -31,7 +31,9 @@ from fold import (fold, FoldResult, read_lines, dedupe_and_sort, external_owners
 
 LOG = ".work/todo.jsonl"
 PATHS = (".work/todo.jsonl", ".work/done.jsonl")
-MAX_BODY = 2048  # derived from PIPE_BUF (section 8.3). Not a setting.
+MAX_BODY = 2048  # body UTF-8 bytes; derived from PIPE_BUF (section 8.3). Not a setting.
+MAX_LINE = 4096  # POSIX PIPE_BUF; the whole encoded event must fit for atomicity.
+LOCK = ".work/.lock"
 VERSION = "0.24.9"  # kept in step with plugin/.claude-plugin/plugin.json by tests/test_plugin.py
 
 
@@ -64,24 +66,40 @@ def append(event):
     Also self-heals a missing trailing newline on the existing file (a hand
     edit the hook hasn't caught yet): appending without the repair would fuse
     two events into one unparseable line and lose both (section 8.2).
+
+    Holds `.work/.lock` so a concurrent compact cannot os.replace the inode
+    this write is targeting (spec §8.3).
     """
-    if len(event.get("set", {}).get("body", "")) > MAX_BODY:
+    body = event.get("set", {}).get("body", "")
+    if isinstance(body, str) and len(body.encode("utf-8")) > MAX_BODY:
         sys.exit(f"worklog: body exceeds {MAX_BODY}B; put prose in the plan doc")
     _warn_concurrent_sessions()
     line = json.dumps(event, separators=(",", ":"), sort_keys=True) + "\n"
-    fd = os.open(LOG, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    raw = line.encode("utf-8")
+    if len(raw) > MAX_LINE:
+        sys.exit(f"worklog: event exceeds {MAX_LINE}B atomicity envelope "
+                 "(PIPE_BUF); shorten title or move prose to the plan doc")
+    os.makedirs(os.path.dirname(LOG) or ".", exist_ok=True)
+    lock_fd = os.open(LOCK, os.O_RDWR | os.O_CREAT, 0o644)
     try:
-        if os.fstat(fd).st_size:
-            rfd = os.open(LOG, os.O_RDONLY)
-            try:
-                os.lseek(rfd, -1, os.SEEK_END)
-                if os.read(rfd, 1) != b"\n":
-                    line = "\n" + line
-            finally:
-                os.close(rfd)
-        os.write(fd, line.encode())   # atomic under PIPE_BUF
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        fd = os.open(LOG, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+        try:
+            if os.fstat(fd).st_size:
+                rfd = os.open(LOG, os.O_RDONLY)
+                try:
+                    os.lseek(rfd, -1, os.SEEK_END)
+                    if os.read(rfd, 1) != b"\n":
+                        raw = b"\n" + raw
+                finally:
+                    os.close(rfd)
+            n = os.write(fd, raw)
+            if n != len(raw):
+                sys.exit("worklog: short write; event not recorded")
+        finally:
+            os.close(fd)
     finally:
-        os.close(fd)
+        os.close(lock_fd)
     return event
 
 

--- a/plugin/tests/test_three_host_hooks.py
+++ b/plugin/tests/test_three_host_hooks.py
@@ -1,24 +1,55 @@
-"""Claude hooks imply Codex + Cursor-native hooks."""
-from pathlib import Path
+#!/usr/bin/env python3
+"""Claude hooks imply Codex + Cursor-native hooks.
+
+Cursor command paths must resolve against the plugin root (marketplace
+source is `./plugin`), not `./plugin/hooks/...` which cannot resolve when
+the pack is installed from that source.
+"""
 import json
+import os
+import unittest
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HOOKS = ROOT / "hooks"
 
 
-def test_three_host_hooks_coexist():
-    claude = HOOKS / "hooks.json"
-    if not claude.is_file():
-        return
-    assert (HOOKS / "codex-hooks.json").is_file(), "Codex hooks required when Claude hooks exist"
-    assert (HOOKS / "cursor-hooks.json").is_file(), "Cursor-native hooks required when Claude hooks exist"
-    for name in ("codex-hooks.json", "cursor-hooks.json"):
-        data = json.loads((HOOKS / name).read_text())
-        assert "hooks" in data and isinstance(data["hooks"], dict)
-        for entries in data["hooks"].values():
-            for item in entries if isinstance(entries, list) else []:
+class TestThreeHostHooks(unittest.TestCase):
+    def test_three_host_hooks_coexist(self):
+        claude = HOOKS / "hooks.json"
+        if not claude.is_file():
+            self.skipTest("no Claude hooks")
+        self.assertTrue((HOOKS / "codex-hooks.json").is_file(),
+                        "Codex hooks required when Claude hooks exist")
+        self.assertTrue((HOOKS / "cursor-hooks.json").is_file(),
+                        "Cursor-native hooks required when Claude hooks exist")
+        for name in ("codex-hooks.json", "cursor-hooks.json"):
+            data = json.loads((HOOKS / name).read_text())
+            self.assertIn("hooks", data)
+            self.assertIsInstance(data["hooks"], dict)
+            for entries in data["hooks"].values():
+                for item in entries if isinstance(entries, list) else []:
+                    cmd = item.get("command") or ""
+                    nested = item.get("hooks") or []
+                    if nested:
+                        cmd = nested[0].get("command", cmd)
+                    self.assertIsInstance(cmd, str)
+                    self.assertTrue(cmd.strip())
+
+    def test_cursor_hook_paths_resolve_from_plugin_root(self):
+        data = json.loads((HOOKS / "cursor-hooks.json").read_text())
+        for ev, entries in data["hooks"].items():
+            for item in entries:
                 cmd = item.get("command") or ""
-                nested = item.get("hooks") or []
-                if nested:
-                    cmd = nested[0].get("command", cmd)
-                assert isinstance(cmd, str) and cmd.strip()
+                self.assertFalse(
+                    cmd.startswith("./plugin/"),
+                    "%s: %s cannot resolve when marketplace source is ./plugin"
+                    % (ev, cmd))
+                rel = cmd[2:] if cmd.startswith("./") else cmd
+                path = ROOT / rel
+                self.assertTrue(path.is_file(), "%s -> %s" % (cmd, path))
+                self.assertTrue(os.access(path, os.X_OK), cmd)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_compact.py
+++ b/tests/test_compact.py
@@ -218,5 +218,53 @@ class TestTheBugThisPrevents(unittest.TestCase):
         self.assertEqual(before, after)
 
 
+class TestConflictPreservation(CompactBase):
+    """Open `_conflicts` are private fold state. Snapshots are built from
+    `_public()`, which strips them; without re-emitting `conflict` events
+    above the snapshot, every open conflict dies at the next compact."""
+
+    CONFLICT = {
+        "ev": "01A9", "ts": "t", "actor": "sync", "item": "A",
+        "op": "conflict",
+        "set": {"field": "title", "local": "a title",
+                "remote": "remote title", "remote_rev": "r1"},
+    }
+
+    def test_open_conflicts_survive_compaction(self):
+        with open(self.todo, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(self.CONFLICT) + "\n")
+        before = fold([self.todo, self.done])
+        self.assertEqual(before.items["A"]["_conflicts"][0]["remote"],
+                         "remote title")
+        compact(self.todo, self.done)
+        after = fold([self.todo, self.done])
+        self.assertEqual(before.items["A"]["_conflicts"],
+                         after.items["A"]["_conflicts"])
+        ops = [e["op"] for e in read_events(self.todo) if e.get("item") == "A"]
+        self.assertIn("snapshot", ops)
+        self.assertIn("conflict", ops)
+        # Conflict must sort after the snapshot, or the snapshot would
+        # drop it again (fold starts a snapshot from a fresh dict).
+        a_events = [e for e in read_events(self.todo) if e.get("item") == "A"]
+        ops_in_ev_order = [e["op"] for e in sorted(a_events, key=lambda x: x["ev"])]
+        self.assertLess(ops_in_ev_order.index("snapshot"),
+                        ops_in_ev_order.index("conflict"))
+
+    def test_closed_item_conflicts_land_in_done(self):
+        with open(self.todo, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "ev": "01A9", "ts": "t", "actor": "sync", "item": "C",
+                "op": "conflict",
+                "set": {"field": "title", "local": "c title",
+                        "remote": "other", "remote_rev": "r2"},
+            }) + "\n")
+        compact(self.todo, self.done)
+        c = fold([self.done]).items["C"]
+        self.assertEqual(c["status"], "done")
+        self.assertEqual(c["_conflicts"][0]["remote"], "other")
+        self.assertIn("conflict", [e["op"] for e in read_events(self.done)
+                                   if e.get("item") == "C"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -72,6 +72,19 @@ class Sandbox(unittest.TestCase):
     def show(self, item):
         return json.loads(self.wl("show", item))
 
+    def cursor(self, system="fake"):
+        path = os.path.join(self.dir, ".work", "sync-state.json")
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh).get("cursors", {}).get(system)
+
+    def set_cursor(self, value, system="fake"):
+        path = os.path.join(self.dir, ".work", "sync-state.json")
+        with open(path, encoding="utf-8") as fh:
+            st = json.load(fh)
+        st.setdefault("cursors", {})[system] = value
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(st, fh)
+
 
 class TestIdempotency(Sandbox):
     def test_push_twice_same_ulid_is_one_ticket(self):
@@ -169,6 +182,60 @@ class TestPull(Sandbox):
         evs = {e["ev"] for e in self.ingest_events()}
         self.assertEqual(len(evs), 1, self.ingest_events())
         self.assertEqual(self.show(item)["title"], "Remote title")
+
+    def test_failed_ingest_does_not_advance_cursor(self):
+        """A remote edit whose ingest fails must be retried next poll, not
+        skipped until the ticket changes again."""
+        item = self.wl("add", "Cursor hold", "--priority", "P1").strip()
+        self.sync("--push-only")
+        self.sync("--pull-only")
+        before = self.cursor()
+        self.assertIsNotNone(before)
+        self.edit_remote(lambda t: t["item"].__setitem__("body", "x" * 3000))
+        p = self.run_wl("sync", "--retry-base-delay", "0", "--pull-only")
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        self.assertEqual(self.cursor(), before, p.stdout + p.stderr)
+        self.assertIn("held", (p.stdout + p.stderr).lower())
+        # Repair the remote and the same rev-or-later edit is picked up.
+        self.edit_remote(lambda t: t["item"].__setitem__("body", "ok"))
+        self.sync("--pull-only")
+        self.assertEqual(self.show(item).get("body"), "ok")
+
+    def test_keys_pulls_even_when_since_cursor_is_ahead(self):
+        item = self.wl("add", "Keyed", "--priority", "P1").strip()
+        self.sync("--push-only")
+        self.set_cursor(FUTURE_REV)
+        self.edit_remote(lambda t: t["item"].__setitem__("title", "From keys"))
+        self.sync("--pull-only", "--keys", "FAKE#1")
+        self.assertEqual(self.show(item)["title"], "From keys")
+        # Point query must not rewind or advance the since cursor.
+        self.assertEqual(self.cursor(), FUTURE_REV)
+
+
+class TestTicketEnv(Sandbox):
+    def test_dispatcher_exports_project_from_config(self):
+        with open(os.path.join(self.dir, ".work", "config.yml"), "w",
+                  encoding="utf-8") as fh:
+            fh.write("ticketing:\n  system: github\n  project: acme/proj\n")
+        probe = os.path.join(self.dir, "probe-adapter")
+        with open(probe, "w", encoding="utf-8") as fh:
+            fh.write(
+                "#!/bin/sh\n"
+                'if [ "$1" = capabilities ]; then\n'
+                '  printf \'{"system":"github","supports":["pull"],'
+                '"types":{"task":"Issue"},'
+                '"marker":{"style":"html","template":"x{ulid}"},'
+                '"fields":{},"max_title":1}\\n\'\n'
+                "  exit 0\n"
+                "fi\n"
+                'echo "PROJECT=$WORKLOG_TICKET_PROJECT" >&2\n'
+                "exit 0\n")
+        os.chmod(probe, 0o755)
+        env = {k: v for k, v in self.env.items()
+               if k not in ("WORKLOG_TICKET_PROJECT", "WORKLOG_TICKET_SYSTEM")}
+        env["WORKLOG_TICKET_ADAPTER"] = probe
+        p = self.run_wl("sync", "--retry-base-delay", "0", "--pull-only", env=env)
+        self.assertIn("PROJECT=acme/proj", p.stderr)
 
 
 class TestCloseSyncsFields(Sandbox):

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -257,6 +257,35 @@ class TestPullEmitsUnmarked(unittest.TestCase):
         self.assertNotIn("worklog:", line.get("body") or "")
         self.assertNotIn("worklog id", line.get("body") or "")
 
+    def test_pull_emits_readable_body(self):
+        issue = dict(MARKED)
+        issue["body"] = (MARKED["body"] + "\n\nThe actual description.")
+        with open(self.responses, "w", encoding="utf-8") as fh:
+            json.dump({
+                "issue list search": {"out": json.dumps([issue])},
+                "issue list open": {"out": json.dumps([issue])},
+            }, fh)
+        p = subprocess.run(
+            [sys.executable, ADAPTER, "pull", "--since", "1970-01-01T00:00:00Z"],
+            capture_output=True, text=True, env=self.env)
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        lines = [json.loads(l) for l in p.stdout.splitlines() if l.strip()]
+        self.assertEqual(lines[0]["body"], "The actual description.")
+        self.assertNotIn("worklog:", lines[0]["body"])
+
+    def test_listing_cap_warns_at_1000(self):
+        issues = [dict(MARKED, number=i) for i in range(1000)]
+        with open(self.responses, "w", encoding="utf-8") as fh:
+            json.dump({
+                "issue list search": {"out": json.dumps(issues)},
+                "issue list open": {"out": "[]"},
+            }, fh)
+        p = subprocess.run(
+            [sys.executable, ADAPTER, "pull", "--since", "1970-01-01T00:00:00Z"],
+            capture_output=True, text=True, env=self.env)
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        self.assertIn("capped at 1000", p.stderr)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_merge_green.py
+++ b/tests/test_merge_green.py
@@ -25,7 +25,16 @@ case "$1" in
         n=$(cat "$D/call" 2>/dev/null || echo 0); echo $((n+1)) > "$D/call"
         sed -n "$((n+1))p" "$D/buckets" | tr -d '\\n'
         ;;
-      merge) echo "$@" >> "$D/merged"; exit 0 ;;
+      merge)
+        for a in "$@"; do
+          if [ "$a" = "--auto" ]; then
+            echo "$@" >> "$D/armed"
+            exit 0
+          fi
+        done
+        echo "$@" >> "$D/merged"
+        exit 0
+        ;;
     esac ;;
 esac
 """
@@ -60,6 +69,9 @@ class Sandbox:
 
     def merged(self):
         return os.path.exists(os.path.join(self.dir, "merged"))
+
+    def armed(self):
+        return os.path.exists(os.path.join(self.dir, "armed"))
 
 
 class TestMergeWhenGreen(unittest.TestCase):
@@ -122,6 +134,25 @@ class TestMergeWhenGreen(unittest.TestCase):
         sb = Sandbox(self, ["", "", ""])
         r = sb.run(max_attempts=2)
         self.assertEqual(r.returncode, 4)   # no gates reporting != gates passing
+        self.assertFalse(sb.merged())
+
+    def test_auto_merge_is_armed_before_checks_complete(self):
+        sb = Sandbox(self, ["pending,pass", "pass,pass"])
+        r = sb.run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue(sb.armed(), r.stderr)
+        self.assertTrue(sb.merged())
+        with open(os.path.join(sb.dir, "armed")) as fh:
+            armed = fh.read()
+        self.assertIn("--auto", armed)
+        self.assertIn("--merge", armed)
+
+    def test_advisory_does_not_arm_auto_merge(self):
+        sb = Sandbox(self, ["pass,pass"],
+                     config="features:\n  auto_merge_on_green: false\n")
+        r = sb.run()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertFalse(sb.armed())
         self.assertFalse(sb.merged())
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -311,6 +311,24 @@ class TestVersionSync(unittest.TestCase):
                          f"README.md advertises {sorted(set(found))}, "
                          f"plugin.json says {v}")
 
+    def test_root_manifests_agree(self):
+        """Marketplace / host pins rot independently of plugin.json (#cursor)."""
+        v = plugin_version()
+        roots = [
+            os.path.join(ROOT, "plugin.json"),
+            os.path.join(ROOT, ".cursor-plugin", "plugin.json"),
+            os.path.join(ROOT, ".grok-plugin", "marketplace.json"),
+        ]
+        for path in roots:
+            with open(path, encoding="utf-8") as fh:
+                data = json.load(fh)
+            if "plugins" in data:
+                versions = {data.get("version")} | {
+                    p.get("version") for p in data["plugins"]}
+                self.assertEqual(versions, {v}, path)
+            else:
+                self.assertEqual(data.get("version"), v, path)
+
 
 class TestSuiteHygiene(unittest.TestCase):
     """No test file may define a class below its `if __name__` block.
@@ -439,6 +457,26 @@ class TestDoctor(unittest.TestCase):
         p = sh(d, "bash", doctor, check=False)
         self.assertEqual(p.returncode, 1)
         self.assertIn("skew", p.stdout + p.stderr)
+
+    def test_fix_wiring_restores_hooks_path(self):
+        d = init_repo(self)
+        iid = worklog(d, "add", "Item", "--priority", "P2").stdout.strip()
+        worklog(d, "roadmap-render")
+        sh(d, "git", "checkout", "-q", "-b", "work")
+        sh(d, "git", "add", "-A")
+        sh(d, "git", "commit", "-q", "-m", f"base: {iid}")
+        sh(d, "git", "config", "--unset", "core.hooksPath")
+        sh(d, "git", "config", "--unset", "merge.ours.driver")
+        doctor = os.path.join(PLUGIN, "scripts", "doctor.sh")
+        p = sh(d, "bash", doctor, check=False)
+        self.assertEqual(p.returncode, 1)
+        self.assertIn("hooksPath", p.stdout + p.stderr)
+        p = sh(d, "bash", doctor, "--fix-wiring")
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+        path = sh(d, "git", "config", "core.hooksPath").stdout.strip()
+        self.assertEqual(path, "hooks")
+        driver = sh(d, "git", "config", "merge.ours.driver").stdout.strip()
+        self.assertEqual(driver, "true")
 
 
 class TestUninstall(unittest.TestCase):

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -59,6 +59,13 @@ class TestDeterministic(unittest.TestCase):
     def test_local_ulids_are_not_deterministic(self):
         self.assertNotEqual(ulid.new(1_700_000_000_000), ulid.new(1_700_000_000_000))
 
+    def test_same_millisecond_ids_are_monotonic(self):
+        """Create-then-update in one tick must fold in that order."""
+        ms = 1_700_000_000_000
+        ids = [ulid.new(ms) for _ in range(32)]
+        self.assertEqual(ids, sorted(ids))
+        self.assertEqual(len(set(ids)), 32)
+
 
 class TestTheBugThisPrevents(unittest.TestCase):
     """Section 10.2, end to end.
@@ -116,7 +123,7 @@ class TestEntropyIsNeverSpent(unittest.TestCase):
     def test_full_entropy_is_random_across_the_whole_tail(self):
         """Every entropy position must vary. If any five consecutive ones are
         constant across many ids, something is stamping them again."""
-        ids = [ulid.new(timestamp_ms=1785000000000) for _ in range(500)]
+        ids = [ulid.new(timestamp_ms=1785000000000 + i) for i in range(500)]
         for pos in range(10, 26):
             distinct = {i[pos] for i in ids}
             self.assertGreater(len(distinct), 1,


### PR DESCRIPTION
Closes #390.

P0/P1 correctness from the v0.24.9 architecture review. Union-merge/fold is sound; this PR does not change it. **Merge commit only — never squash (ADR-0008).**

## P0

**Compaction no longer drops open conflicts.** Snapshots are built from `_public()`, which strips `_conflicts`, and `_verify` compared `_public` on both sides, so the nightly compact was structurally blind to the loss. Compact now re-emits `conflict` events above each snapshot (monotonic ULIDs keep them after the snapshot) and verifies the private map too.

**Merge bootstrap self-heals.** SessionStart doctor writes `merge.ours.driver` and `core.hooksPath` (absolute in linked worktrees). That is the Catch-22: pre-commit would self-heal the driver, but pre-commit never runs until hooksPath is set. `doctor --fix-wiring` does the same on demand; `init.sh` is worktree-aware.

`published.json` is **not** converted in this PR (too risky for a first correctness drop).

## P1

- **Write envelope:** whole encoded event is byte-capped at PIPE_BUF (4096); `os.write` return is checked; `.work/.lock` is flocked so compact cannot `os.replace` the inode mid-append.
- **Monotonic ULIDs:** `ulid.new()` increments the 80-bit entropy inside the same millisecond so create-then-update cannot fold out of order. `test_local_ulids_are_not_deterministic` still holds (increment ≠ same id).
- **Pull cursor:** a failed ingest/conflict write holds the since-cursor instead of skipping that remote edit until the ticket changes again. `--keys` is forwarded to the adapter as a point query (does not move the cursor). `WORKLOG_TICKET_PROJECT` is exported from `ticketing.project` when unset.
- **GitHub body:** `to_line` emits a readable body (cmd_get no longer has a private copy), so remote body edits conflict instead of being clobbered on the next push. Listing warns at the 1000-issue cap.
- **Faster merge:** `merge-when-green` arms `gh pr merge --auto --merge` up front; the poll interval is 60s as fallback. Fake `gh` treats `--auto` as armed, not merged.
- **Cursor port:** `cursor-hooks.json` paths are `./hooks/scripts/...` so they resolve when marketplace source is `./plugin`. Host-parity test is a real unittest in CI. `.grok-plugin/marketplace.json` locksteps to 0.24.9.

## Explicitly not in this PR

OKF eviction, typed wiki publish, triggers YAML, converting `published.json`, spec/HOSTS/PORTS hygiene, README positioning.

## Tests

- `tests/test_compact.py` — open and closed conflicts survive compaction
- `tests/test_ulid.py` — same-ms ids are monotonic
- `tests/test_dispatch.py` — cursor hold, `--keys` pull, config→env project
- `tests/test_github_adapter.py` — pull emits body; 1000-cap warning
- `tests/test_merge_green.py` — `--auto` is armed, not merged
- `tests/test_plugin.py` — `doctor --fix-wiring`, root-manifest version lockstep
- `plugin/tests/test_three_host_hooks.py` — now a unittest with `__main__`; Cursor paths resolve

CI now runs `test_compact.py`, `test_github_adapter.py`, `test_merge_green.py`, and the host-parity test on every PR.
